### PR TITLE
Match a few MarioAnimator functions and related functions

### DIFF
--- a/csv/Animation.csv
+++ b/csv/Animation.csv
@@ -169,7 +169,7 @@ getMainAnimationTrans__12XanimePlayerCFUlPQ29JGeometry8TVec3<f>,XanimePlayer.o,A
 isRun__12XanimePlayerCFPCc,XanimePlayer.o,Animation.a,false
 isTerminate__12XanimePlayerCFPCc,XanimePlayer.o,Animation.a,false
 isTerminate__12XanimePlayerCFv,XanimePlayer.o,Animation.a,false
-setDefaultAnimation__12XanimePlayerFPCc,XanimePlayer.o,Animation.a,false
+setDefaultAnimation__12XanimePlayerFPCc,XanimePlayer.o,Animation.a,true
 runDefaultAnimation__12XanimePlayerFv,XanimePlayer.o,Animation.a,false
 isAnimationRunSimple__12XanimePlayerCFv,XanimePlayer.o,Animation.a,false
 getCurrentAnimationName__12XanimePlayerCFv,XanimePlayer.o,Animation.a,false

--- a/csv/Animation.csv
+++ b/csv/Animation.csv
@@ -180,7 +180,7 @@ checkPass__12XanimePlayerCFf,XanimePlayer.o,Animation.a,false
 getSimpleGroup__12XanimePlayerCFv,XanimePlayer.o,Animation.a,false
 duplicateSimpleGroup__12XanimePlayerFv,XanimePlayer.o,Animation.a,false
 __ct__15XanimeFrameCtrlFv,XanimePlayer.o,Animation.a,false
-changeCurrentAnimation__12XanimePlayerFPC15XanimeGroupInfo,XanimePlayer.o,Animation.a,false
+changeCurrentAnimation__12XanimePlayerFPC15XanimeGroupInfo,XanimePlayer.o,Animation.a,true
 __dt__15XanimeFrameCtrlFv,XanimePlayer.o,Animation.a,false
 init__19XanimeResourceTableFv,XanimeResource.o,Animation.a,false
 getGroupInfo__19XanimeResourceTableCFPCc,XanimeResource.o,Animation.a,false

--- a/csv/Player.csv
+++ b/csv/Player.csv
@@ -263,7 +263,7 @@ initTornadoMario__10MarioActorFv,MarioActorDraw.o,Player.a,false
 initBoneMario__10MarioActorFv,MarioActorDraw.o,Player.a,false
 changeDisplayMode__10MarioActorFUc,MarioActorDraw.o,Player.a,false
 calcViewAndEntry__10MarioActorFv,MarioActorDraw.o,Player.a,false
-drawMarioModel__10MarioActorCFv,MarioActorDraw.o,Player.a,false
+drawMarioModel__10MarioActorCFv,MarioActorDraw.o,Player.a,true
 isAllHidden__10MarioActorCFv,MarioActorDraw.o,Player.a,false
 swapTextureInit__10MarioActorFv,MarioActorDraw.o,Player.a,false
 initFace__10MarioActorFv,MarioActorDraw.o,Player.a,false

--- a/csv/Player.csv
+++ b/csv/Player.csv
@@ -582,11 +582,11 @@ getUpperFrame__13MarioAnimatorCFv,MarioAnimator.o,Player.a,false
 setWalkMode__13MarioAnimatorFv,MarioAnimator.o,Player.a,false
 calc__13MarioAnimatorFv,MarioAnimator.o,Player.a,false
 change__13MarioAnimatorFPCc,MarioAnimator.o,Player.a,false
-changeUpper__13MarioAnimatorFPCc,MarioAnimator.o,Player.a,false
+changeUpper__13MarioAnimatorFPCc,MarioAnimator.o,Player.a,true
 stopUpper__13MarioAnimatorFPCc,MarioAnimator.o,Player.a,false
-changeDefault__13MarioAnimatorFPCc,MarioAnimator.o,Player.a,false
+changeDefault__13MarioAnimatorFPCc,MarioAnimator.o,Player.a,true
 isDefaultAnimationRun__13MarioAnimatorCFPCc,MarioAnimator.o,Player.a,false
-changeDefaultUpper__13MarioAnimatorFPCc,MarioAnimator.o,Player.a,false
+changeDefaultUpper__13MarioAnimatorFPCc,MarioAnimator.o,Player.a,true
 getUpperJointID__13MarioAnimatorCFv,MarioAnimator.o,Player.a,false
 updateJointRumble__13MarioAnimatorFv,MarioAnimator.o,Player.a,false
 addRumblePower__13MarioAnimatorFfUl,MarioAnimator.o,Player.a,false

--- a/csv/Player.csv
+++ b/csv/Player.csv
@@ -558,7 +558,7 @@ exeGameOverBlackHole2__10MarioActorFv,MarioActorBlackHole.o,Player.a,false
 __sinit_\MarioActorBlackHole_cpp,MarioActorBlackHole.o,Player.a,false
 __ct__13MarioAnimatorFP10MarioActor,MarioAnimator.o,Player.a,true
 init__13MarioAnimatorFv,MarioAnimator.o,Player.a,true
-isAnimationStop__13MarioAnimatorCFv,MarioAnimator.o,Player.a,false
+isAnimationStop__13MarioAnimatorCFv,MarioAnimator.o,Player.a,true
 targetWeight__13MarioAnimatorFPfff,MarioAnimator.o,Player.a,false
 setWalkWeight__13MarioAnimatorFPCf,MarioAnimator.o,Player.a,false
 setBlendWeight__13MarioAnimatorFPCff,MarioAnimator.o,Player.a,false

--- a/include/Game/Animation/XanimePlayer.hpp
+++ b/include/Game/Animation/XanimePlayer.hpp
@@ -33,8 +33,9 @@ public:
     void setDefaultAnimation(const char *);
 
     void changeAnimation(const char *);
-    
     void changeAnimation(const XanimeGroupInfo *);
+
+    void changeCurrentAnimation(const XanimeGroupInfo *);
 
     inline XanimeCore* getCore() {
         return mCore;
@@ -44,8 +45,9 @@ public:
     J3DModelData *mModelData;   // _4
     u8 _8[0x5C-8];
     const XanimeGroupInfo *mDefaultAnimation; // _5C
-    const XanimeGroupInfo *mStopAnimation; // _60
-    u8 _64[8];
+    const XanimeGroupInfo *mCurrentAnimation; // _60
+    const XanimeGroupInfo *mPrevAnimation; // _64
+    const XanimeGroupInfo *_68;
     XanimeCore *mCore;          // _6C
     XanimeResourceTable *mResourceTable; // _70
     u8 _74[0x8];

--- a/include/Game/Animation/XanimePlayer.hpp
+++ b/include/Game/Animation/XanimePlayer.hpp
@@ -2,6 +2,7 @@
 
 #include <revolution.h>
 #include "Game/Animation/XanimeCore.hpp"
+#include "Game/Animation/XanimeResource.hpp"
 #include "JSystem/J3DGraphAnimator/J3DModel.hpp"
 
 class XanimeResourceTable;
@@ -27,20 +28,28 @@ public:
 
     const char* getCurrentAnimationName() const;
 
+    const char* getCurrentBckName() const;
+
     void setDefaultAnimation(const char *);
 
     void changeAnimation(const char *);
+    
+    void changeAnimation(const XanimeGroupInfo *);
 
     inline XanimeCore* getCore() {
         return mCore;
     }
 
     J3DModel *mModel;            // _0
-    J3DModelData* mModelData;   // _4
+    J3DModelData *mModelData;   // _4
     u8 _8[0x5C-8];
-    u32 _5C;
-    u32 _60;
+    const XanimeGroupInfo *mDefaultAnimation; // _5C
+    const XanimeGroupInfo *mStopAnimation; // _60
     u8 _64[8];
-    XanimeCore* mCore;          // _6C
-    u8 _70[0x1C];
+    XanimeCore *mCore;          // _6C
+    XanimeResourceTable *mResourceTable; // _70
+    u8 _74[0x8];
+    bool _7C;
+    bool _7D;
+    u8 _7E[0x8C - 0x7E];
 };

--- a/include/Game/Animation/XanimePlayer.hpp
+++ b/include/Game/Animation/XanimePlayer.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <revolution.h>
 #include "Game/Animation/XanimeCore.hpp"
 #include "Game/Animation/XanimeResource.hpp"
 #include "JSystem/J3DGraphAnimator/J3DModel.hpp"
+#include <revolution.h>
 
 class XanimeResourceTable;
 
@@ -23,12 +23,12 @@ public:
     void changeAnimationBck(const char *);
 
     void changeInterpoleFrame(s32);
-    
+
     void changeTrackAnimation(unsigned char, const char *);
 
-    const char* getCurrentAnimationName() const;
+    const char *getCurrentAnimationName() const;
 
-    const char* getCurrentBckName() const;
+    const char *getCurrentBckName() const;
 
     void setDefaultAnimation(const char *);
 
@@ -37,19 +37,17 @@ public:
 
     void changeCurrentAnimation(const XanimeGroupInfo *);
 
-    inline XanimeCore* getCore() {
-        return mCore;
-    }
+    inline XanimeCore *getCore() { return mCore; }
 
     J3DModel *mModel;            // _0
-    J3DModelData *mModelData;   // _4
-    u8 _8[0x5C-8];
-    const XanimeGroupInfo *mDefaultAnimation; // _5C
-    const XanimeGroupInfo *mCurrentAnimation; // _60
-    const XanimeGroupInfo *mPrevAnimation; // _64
+    J3DModelData *mModelData;    // _4
+    u8 _8[0x5C - 8];
+    const XanimeGroupInfo *mDefaultAnimation;    // _5C
+    const XanimeGroupInfo *mCurrentAnimation;    // _60
+    const XanimeGroupInfo *mPrevAnimation;       // _64
     const XanimeGroupInfo *_68;
-    XanimeCore *mCore;          // _6C
-    XanimeResourceTable *mResourceTable; // _70
+    XanimeCore *mCore;                      // _6C
+    XanimeResourceTable *mResourceTable;    // _70
     u8 _74[0x8];
     bool _7C;
     bool _7D;

--- a/include/Game/Animation/XanimePlayer.hpp
+++ b/include/Game/Animation/XanimePlayer.hpp
@@ -37,7 +37,10 @@ public:
 
     J3DModel *mModel;            // _0
     J3DModelData* mModelData;   // _4
-    u8 _8[0x6C-0x8];
+    u8 _8[0x5C-8];
+    u32 _5C;
+    u32 _60;
+    u8 _64[8];
     XanimeCore* mCore;          // _6C
     u8 _70[0x1C];
 };

--- a/include/Game/Animation/XanimeResource.hpp
+++ b/include/Game/Animation/XanimeResource.hpp
@@ -123,7 +123,7 @@ public:
 
     XanimeResourceTable(ResourceHolder *);
 
-    const XanimeGroupInfo* getGroupInfo(const char *) const;
+    const XanimeGroupInfo *getGroupInfo(const char *) const;
 
     u8 _0[0x78];
 };

--- a/include/Game/Animation/XanimeResource.hpp
+++ b/include/Game/Animation/XanimeResource.hpp
@@ -17,7 +17,7 @@ public:
 
 class XanimeGroupInfo {
 public:
-    XanimeBckTable mParent; // _0
+    XanimeBckTable mParent;    // _0
     f32 _4;
     u32 _8;
     f32 _C;
@@ -37,71 +37,71 @@ public:
 
 class XanimeSingleBckTable {
 public:
-    XanimeBckTable parent; // _0
-    
-    const char *fileName; // _4
-    u32 animationHash; // _8
-    u32 fileHash; // _C
+    XanimeBckTable parent;    // _0
+
+    const char *fileName;    // _4
+    u32 animationHash;       // _8
+    u32 fileHash;            // _C
 };
 
 class XanimeDoubleBckTable {
 public:
-    XanimeBckTable parent; // _0
-    
-    const char *fileName1; // _4
+    XanimeBckTable parent;    // _0
+
+    const char *fileName1;    // _4
     f32 _8;
-    
-    const char *fileName2; // _C
+
+    const char *fileName2;    // _C
     f32 _10;
 };
 
 class XanimeTripleBckTable {
 public:
-    XanimeBckTable parent; // _0
-    
-    const char *fileName1; // _4
+    XanimeBckTable parent;    // _0
+
+    const char *fileName1;    // _4
     f32 _8;
-    
-    const char *fileName2; // _C
+
+    const char *fileName2;    // _C
     f32 _10;
 
-    const char *fileName3; // _14;
+    const char *fileName3;    // _14;
     f32 _18;
 };
 
 class XanimeQuadBckTable {
 public:
-    XanimeBckTable parent; // _0
-    
-    const char *fileName1; // _4
+    XanimeBckTable parent;    // _0
+
+    const char *fileName1;    // _4
     f32 _8;
-    
-    const char *fileName2; // _C
+
+    const char *fileName2;    // _C
     f32 _10;
 
-    const char *fileName3; // _14;
+    const char *fileName3;    // _14;
     f32 _18;
-    
-    const char *fileName4; // _1C;
+
+    const char *fileName4;    // _1C;
     f32 _20;
 };
 
 // Size is 0x14
 class XanimeOfsInfo {
 public:
-    XanimeBckTable parent; // _0
-    
+    XanimeBckTable parent;    // _0
+
     f32 _4;
     f32 _8;
     f32 _C;
     u32 _10;
 };
 
-//size is 0x18
+// size is 0x18
 class XanimeAuxInfo {
 public:
-    XanimeBckTable parent; // _0
-    
+    XanimeBckTable parent;    // _0
+
     u8 _4;
     u32 _8;
 
@@ -111,24 +111,19 @@ public:
 
 class XanimeResourceTable {
 public:
-
-    XanimeResourceTable (
+    XanimeResourceTable(
 
         ResourceHolder *,
 
-        XanimeGroupInfo *,
-        XanimeAuxInfo *,
-        XanimeOfsInfo *,
+        XanimeGroupInfo *, XanimeAuxInfo *, XanimeOfsInfo *,
 
-        XanimeBckTable *,
-        XanimeBckTable *,
-        XanimeBckTable *,
-        XanimeBckTable *,
+        XanimeBckTable *, XanimeBckTable *, XanimeBckTable *, XanimeBckTable *,
 
-        XanimeSwapTable *
-    );
+        XanimeSwapTable *);
 
     XanimeResourceTable(ResourceHolder *);
+
+    const XanimeGroupInfo* getGroupInfo(const char *) const;
 
     u8 _0[0x78];
 };

--- a/include/Game/Player/DLchanger.hpp
+++ b/include/Game/Player/DLchanger.hpp
@@ -1,0 +1,9 @@
+#pragma once
+
+class J3DModelX;
+
+class DLchanger {
+public:
+    void addDL(J3DModelX *);
+    void swap();
+};

--- a/include/Game/Player/J3DModelX.hpp
+++ b/include/Game/Player/J3DModelX.hpp
@@ -20,39 +20,37 @@ public:
     void directDraw(J3DModel *);
 
     struct Flags {
-        inline void clear() {
-            *(u32 *)this = 0;
-        }
-        
-        unsigned _0: 1;
-        unsigned _1: 1;
-        unsigned _2: 1;
-        unsigned _3: 1;
-        unsigned _4: 1;
-        unsigned _5: 1;
-        unsigned _6: 1;
-        unsigned _7: 1;
-        unsigned _8: 1;
-        unsigned _9: 1;
-        unsigned _A: 1;
-        unsigned _B: 1;
-        unsigned _C: 1;
-        unsigned _D: 1;
-        unsigned _E: 1;
-        unsigned _F: 1;
-        unsigned _10: 1;
-        unsigned _11: 1;
-        unsigned _12: 1;
-        unsigned _13: 1;
-        unsigned _14: 1;
-        unsigned _15: 1;
-        unsigned _16: 1;
-        unsigned _17: 1;
-        unsigned _18: 1;
-        unsigned _19: 1;
-        unsigned _1A: 1;
-        unsigned _1B: 1;
-        unsigned _1C: 1;
+        inline void clear() { *(u32 *)this = 0; }
+
+        unsigned _0 : 1;
+        unsigned _1 : 1;
+        unsigned _2 : 1;
+        unsigned _3 : 1;
+        unsigned _4 : 1;
+        unsigned _5 : 1;
+        unsigned _6 : 1;
+        unsigned _7 : 1;
+        unsigned _8 : 1;
+        unsigned _9 : 1;
+        unsigned _A : 1;
+        unsigned _B : 1;
+        unsigned _C : 1;
+        unsigned _D : 1;
+        unsigned _E : 1;
+        unsigned _F : 1;
+        unsigned _10 : 1;
+        unsigned _11 : 1;
+        unsigned _12 : 1;
+        unsigned _13 : 1;
+        unsigned _14 : 1;
+        unsigned _15 : 1;
+        unsigned _16 : 1;
+        unsigned _17 : 1;
+        unsigned _18 : 1;
+        unsigned _19 : 1;
+        unsigned _1A : 1;
+        unsigned _1B : 1;
+        unsigned _1C : 1;
     };
 
     u8 _DC;
@@ -83,9 +81,9 @@ public:
     u32 _1B8;
     u32 _1BC;
     u32 _1C0;
-    u32* _1C4;
-    u32* _1C8;
-    u16* _1CC;
+    u32 *_1C4;
+    u32 *_1C8;
+    u16 *_1CC;
     u8 _1D0;
     f32 _1D4;
     u32 _1D8;

--- a/include/Game/Player/J3DModelX.hpp
+++ b/include/Game/Player/J3DModelX.hpp
@@ -15,6 +15,45 @@ public:
     void storeDisplayList(_GDLObj *, u32);
     void shapePacketDrawFast(J3DShapePacketX *);
     void shapeDrawFast(J3DShapeX *) const;
+    void setDynamicDL(u8 *, u32);
+    void setDrawView(u32);
+    void directDraw(J3DModel *);
+
+    struct Flags {
+        inline void clear() {
+            *(u32 *)this = 0;
+        }
+        
+        unsigned _0: 1;
+        unsigned _1: 1;
+        unsigned _2: 1;
+        unsigned _3: 1;
+        unsigned _4: 1;
+        unsigned _5: 1;
+        unsigned _6: 1;
+        unsigned _7: 1;
+        unsigned _8: 1;
+        unsigned _9: 1;
+        unsigned _A: 1;
+        unsigned _B: 1;
+        unsigned _C: 1;
+        unsigned _D: 1;
+        unsigned _E: 1;
+        unsigned _F: 1;
+        unsigned _10: 1;
+        unsigned _11: 1;
+        unsigned _12: 1;
+        unsigned _13: 1;
+        unsigned _14: 1;
+        unsigned _15: 1;
+        unsigned _16: 1;
+        unsigned _17: 1;
+        unsigned _18: 1;
+        unsigned _19: 1;
+        unsigned _1A: 1;
+        unsigned _1B: 1;
+        unsigned _1C: 1;
+    };
 
     u8 _DC;
     u8 _DD;
@@ -39,7 +78,7 @@ public:
     u32 _128;
     u32 _12C;
     u8 _130[0x1B0 - 0x130];
-    u32 _1B0;
+    Flags mFlags;
     u32 _1B4;
     u32 _1B8;
     u32 _1BC;

--- a/include/Game/Player/MarioActor.hpp
+++ b/include/Game/Player/MarioActor.hpp
@@ -14,6 +14,10 @@ class MarioEffect;
 class MarioAnimator;
 class MarioMessenger;
 class CollisionShadow;
+class DLchanger;
+class J3DModelX;
+class TornadoMario;
+class ModelHolder;
 
 namespace MR {
     unsigned int getFrameBufferWidth();
@@ -131,6 +135,15 @@ public:
     void init2D();
 
     void initDrawAndModel();
+    bool isAllHidden() const;
+    
+    void drawMarioModel() const;
+
+    // Called by drawMarioModel
+    void drawSpinInhibit() const;
+    void drawSphereMask() const;
+    bool drawDarkMask() const;
+    void drawHand() const;
 
     void resetPadSwing();
     void initActionMatrix();
@@ -204,12 +217,11 @@ public:
     };
 
     u8 _8C;
-    u32 _90;
+    DLchanger *mDLchanger;
     u32 _94[0x40];
-    u32 _194;
-    u32 _198;
-    u32 _19C;
-    u8 _1A0;
+    u8 *DL[2];
+    u32 DLSize;
+    u8 currDL;
     u8 _1A1;
     f32 _1A4;
     u16 _1A8;
@@ -303,7 +315,6 @@ public:
     u32 _390;
     u32 _394;
     u32 _398;
-    ;
     u8 _39C;
     u8 _39D;
     u8 _39E;
@@ -399,7 +410,7 @@ public:
     f32 _984;
     u8 _988;
     u8 _989;
-    u32 _98C;
+    TornadoMario *mTornadoMario;
     u8 _990;
     u32 _994;
     u32 _998;
@@ -423,14 +434,14 @@ public:
     u32 _9E8;
     u32 _9EC;
     bool _9F0;
-    bool _9F1;
+    bool mAlphaEnable;
     u16 _9F2;
     TVec3f _9F4;
     u32 _A00;
     u32 _A04;
     u8 _A08;
     u8 _A09;
-    u8 _A0A;
+    u8 mCurrModel;
     u8 _A0B;
     u8 _A0C;
     u32 _A10;
@@ -439,7 +450,7 @@ public:
     u8 _A24;
     u8 _A25;
     // padding
-    u32 _A28[6];
+    J3DModelX *mModels[6];
     u32 _A40;
     u32 _A44;
     u32 _A48;
@@ -450,7 +461,7 @@ public:
     u8 _A59;
     u8 _A5A;
     u8 _A5B;
-    u32 _A5C;
+    ModelHolder *_A5C;
     bool _A60;
     bool _A61;
     bool _A62;

--- a/include/Game/Player/MarioActor.hpp
+++ b/include/Game/Player/MarioActor.hpp
@@ -450,7 +450,7 @@ public:
     u8 _A24;
     u8 _A25;
     // padding
-    J3DModelX *mModels[6];
+    J3DModelX *mModels[6]; // _A28
     u32 _A40;
     u32 _A44;
     u32 _A48;

--- a/include/Game/Player/MarioActor.hpp
+++ b/include/Game/Player/MarioActor.hpp
@@ -136,7 +136,7 @@ public:
 
     void initDrawAndModel();
     bool isAllHidden() const;
-    
+
     void drawMarioModel() const;
 
     // Called by drawMarioModel
@@ -217,11 +217,11 @@ public:
     };
 
     u8 _8C;
-    DLchanger *mDLchanger; // _90
+    DLchanger *mDLchanger;    // _90
     u32 _94[0x40];
-    u8 *mDL[2]; // _194
-    u32 mDLSize; // _19C
-    u8 mCurrDL; // _1A0
+    u8 *mDL[2];     // _194
+    u32 mDLSize;    // _19C
+    u8 mCurrDL;     // _1A0
     u8 _1A1;
     f32 _1A4;
     u16 _1A8;
@@ -410,7 +410,7 @@ public:
     f32 _984;
     u8 _988;
     u8 _989;
-    TornadoMario *mTornadoMario; // _98C
+    TornadoMario *mTornadoMario;    // _98C
     u8 _990;
     u32 _994;
     u32 _998;
@@ -434,14 +434,14 @@ public:
     u32 _9E8;
     u32 _9EC;
     bool _9F0;
-    bool mAlphaEnable; // _9F1
+    bool mAlphaEnable;    // _9F1
     u16 _9F2;
     TVec3f _9F4;
     u32 _A00;
     u32 _A04;
     u8 _A08;
     u8 _A09;
-    u8 mCurrModel; // _A0A
+    u8 mCurrModel;    // _A0A
     u8 _A0B;
     u8 _A0C;
     u32 _A10;
@@ -450,7 +450,7 @@ public:
     u8 _A24;
     u8 _A25;
     // padding
-    J3DModelX *mModels[6]; // _A28
+    J3DModelX *mModels[6];    // _A28
     u32 _A40;
     u32 _A44;
     u32 _A48;

--- a/include/Game/Player/MarioActor.hpp
+++ b/include/Game/Player/MarioActor.hpp
@@ -44,6 +44,7 @@ public:
     bool isAnimationRun(const char *) const;
     void changeNullAnimation(const char *, signed char);
     void clearNullAnimation(signed char);
+    void changeSpecialModeAnimation(const char *);
     bool isStopNullAnimation() const;
     void changeGameOverAnimation();
     XjointTransform *getJointCtrl(const char *) const;

--- a/include/Game/Player/MarioActor.hpp
+++ b/include/Game/Player/MarioActor.hpp
@@ -217,11 +217,11 @@ public:
     };
 
     u8 _8C;
-    DLchanger *mDLchanger;
+    DLchanger *mDLchanger; // _90
     u32 _94[0x40];
-    u8 *DL[2];
-    u32 DLSize;
-    u8 currDL;
+    u8 *mDL[2]; // _194
+    u32 mDLSize; // _19C
+    u8 mCurrDL; // _1A0
     u8 _1A1;
     f32 _1A4;
     u16 _1A8;
@@ -410,7 +410,7 @@ public:
     f32 _984;
     u8 _988;
     u8 _989;
-    TornadoMario *mTornadoMario;
+    TornadoMario *mTornadoMario; // _98C
     u8 _990;
     u32 _994;
     u32 _998;
@@ -434,14 +434,14 @@ public:
     u32 _9E8;
     u32 _9EC;
     bool _9F0;
-    bool mAlphaEnable;
+    bool mAlphaEnable; // _9F1
     u16 _9F2;
     TVec3f _9F4;
     u32 _A00;
     u32 _A04;
     u8 _A08;
     u8 _A09;
-    u8 mCurrModel;
+    u8 mCurrModel; // _A0A
     u8 _A0B;
     u8 _A0C;
     u32 _A10;

--- a/include/Game/Player/MarioAnimator.hpp
+++ b/include/Game/Player/MarioAnimator.hpp
@@ -16,7 +16,7 @@ public:
     void update();
 
     void setHoming();
-    bool isAnimationStop();
+    bool isAnimationStop() const;
     void setSpeed(f32);
     void forceSetBlendWeight(const f32 *);
     void waterToGround();

--- a/include/Game/Player/MarioAnimator.hpp
+++ b/include/Game/Player/MarioAnimator.hpp
@@ -22,6 +22,8 @@ public:
     void waterToGround();
     void initCallbackTable();
     void change(const char *);
+    void changeDefault(const char *);
+    void changeUpper(const char *);
     void changeDefaultUpper(const char *);
     void entryCallback(const char *);
 
@@ -29,8 +31,7 @@ public:
     {
         getPlayer()->startBas(nullptr, false, 0.0f, 0.0f);
 
-        _C->setDefaultAnimation(name);
-        change(name);
+        mXanimePlayer->setDefaultAnimation(name);
     }
 
     inline bool isTeresaClear() const {
@@ -38,8 +39,8 @@ public:
     }
 
     XanimeResourceTable *mResourceTable; // _8
-    XanimePlayer *_C;
-    XanimePlayer *_10;
+    XanimePlayer *mXanimePlayer; // _C
+    XanimePlayer *mXanimePlayerUpper; // _10
     u8 _14;
     u8 _15;
     u8 _16;
@@ -51,7 +52,7 @@ public:
     f32 _58;
     f32 _5C;
     TVec3f _60;
-    u8 _6C;
+    bool _6C;
     f32 _70;
     u32 _74;
     u16 _78;
@@ -60,7 +61,7 @@ public:
     TMtx34f _DC;
     u8 _10C;
     u8 _10D;
-    u8 _10E;
+    bool mUpperDefaultSet; // _10E
     f32 _110;
     const char *mCurrBck; // _114
     f32 _118;

--- a/include/Game/Player/MarioAnimator.hpp
+++ b/include/Game/Player/MarioAnimator.hpp
@@ -23,6 +23,7 @@ public:
     void initCallbackTable();
     void change(const char *);
     void changeDefaultUpper(const char *);
+    void entryCallback(const char *);
 
     inline void f1(const char *name)
     {
@@ -32,7 +33,11 @@ public:
         change(name);
     }
 
-    XanimeResourceTable *_8;
+    inline bool isTeresaClear() const {
+        return !isPlayerModeTeresa();
+    }
+
+    XanimeResourceTable *mResourceTable; // _8
     XanimePlayer *_C;
     XanimePlayer *_10;
     u8 _14;
@@ -57,7 +62,7 @@ public:
     u8 _10D;
     u8 _10E;
     f32 _110;
-    u32 _114;
+    const char *mCurrBck; // _114
     f32 _118;
 
     u8 _11C[8];

--- a/include/Game/Player/MarioAnimator.hpp
+++ b/include/Game/Player/MarioAnimator.hpp
@@ -34,13 +34,11 @@ public:
         mXanimePlayer->setDefaultAnimation(name);
     }
 
-    inline bool isTeresaClear() const {
-        return !isPlayerModeTeresa();
-    }
+    inline bool isTeresaClear() const { return !isPlayerModeTeresa(); }
 
-    XanimeResourceTable *mResourceTable; // _8
-    XanimePlayer *mXanimePlayer; // _C
-    XanimePlayer *mXanimePlayerUpper; // _10
+    XanimeResourceTable *mResourceTable;    // _8
+    XanimePlayer *mXanimePlayer;            // _C
+    XanimePlayer *mXanimePlayerUpper;       // _10
     u8 _14;
     u8 _15;
     u8 _16;
@@ -61,9 +59,9 @@ public:
     TMtx34f _DC;
     u8 _10C;
     u8 _10D;
-    bool mUpperDefaultSet; // _10E
+    bool mUpperDefaultSet;    // _10E
     f32 _110;
-    const char *mCurrBck; // _114
+    const char *mCurrBck;    // _114
     f32 _118;
 
     u8 _11C[8];

--- a/include/Game/Player/ModelHolder.hpp
+++ b/include/Game/Player/ModelHolder.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "Game/LiveActor/LiveActor.hpp"
+
+class ModelHolder : public LiveActor {
+
+};

--- a/include/Game/Player/ModelHolder.hpp
+++ b/include/Game/Player/ModelHolder.hpp
@@ -2,6 +2,4 @@
 
 #include "Game/LiveActor/LiveActor.hpp"
 
-class ModelHolder : public LiveActor {
-
-};
+class ModelHolder : public LiveActor {};

--- a/include/Game/Player/TornadoMario.hpp
+++ b/include/Game/Player/TornadoMario.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "Game/LiveActor/LiveActor.hpp"
+
+class TornadoMario : public LiveActor {
+
+};

--- a/include/Game/Player/TornadoMario.hpp
+++ b/include/Game/Player/TornadoMario.hpp
@@ -2,6 +2,4 @@
 
 #include "Game/LiveActor/LiveActor.hpp"
 
-class TornadoMario : public LiveActor {
-
-};
+class TornadoMario : public LiveActor {};

--- a/include/Game/Util/JointUtil.hpp
+++ b/include/Game/Util/JointUtil.hpp
@@ -4,6 +4,7 @@
 #include "JSystem/JGeometry/TVec.hpp"
 
 class LiveActor;
+class J3DModel;
 
 namespace MR {
     MtxPtr getJointMtx(const LiveActor *, int);
@@ -11,6 +12,9 @@ namespace MR {
 
     void copyJointPos(const LiveActor *, int, TVec3f *);
     void copyJointPos(const LiveActor *, const char *, TVec3f *);
+
+    void showJoint(J3DModel *, const char *);
+    void hideJoint(J3DModel *, const char *);
 
     bool isExistJoint(const LiveActor *, const char *);
 

--- a/libs/JSystem/include/JSystem/JGeometry/TVec.hpp
+++ b/libs/JSystem/include/JSystem/JGeometry/TVec.hpp
@@ -6,7 +6,7 @@
 #include "JSystem/JGeometry/TUtil.hpp"
 #include <JSystem/JMath/JMath.hpp>
 
-extern Vec gZeroVec;
+extern const Vec gZeroVec;
 
 namespace JGeometry {
     void negateInternal(const f32 *rSrc, f32 *rDest);

--- a/source/Game/Animation/XanimePlayer.cpp
+++ b/source/Game/Animation/XanimePlayer.cpp
@@ -1,0 +1,10 @@
+#include "Game/Animation/XanimePlayer.hpp"
+
+void XanimePlayer::setDefaultAnimation(const char *name) {
+    const XanimeGroupInfo *animation = mResourceTable->getGroupInfo(name);
+    if(mStopAnimation == mDefaultAnimation) {
+        changeAnimation(animation);
+    }
+    mDefaultAnimation = animation;
+    _7D = true;
+}

--- a/source/Game/Animation/XanimePlayer.cpp
+++ b/source/Game/Animation/XanimePlayer.cpp
@@ -1,10 +1,17 @@
 #include "Game/Animation/XanimePlayer.hpp"
 
 void XanimePlayer::setDefaultAnimation(const char *name) {
-    const XanimeGroupInfo *animation = mResourceTable->getGroupInfo(name);
-    if(mStopAnimation == mDefaultAnimation) {
-        changeAnimation(animation);
+    const XanimeGroupInfo *defaultAnimation = mResourceTable->getGroupInfo(name);
+    if(mCurrentAnimation == mDefaultAnimation) {
+        changeAnimation(defaultAnimation);
     }
-    mDefaultAnimation = animation;
+    mDefaultAnimation = defaultAnimation;
     _7D = true;
+}
+
+void XanimePlayer::changeCurrentAnimation(const XanimeGroupInfo *animation) {
+    if(mCurrentAnimation == animation) return;
+    mPrevAnimation = mCurrentAnimation;
+    mCurrentAnimation = animation;
+    updateAfterMovement();
 }

--- a/source/Game/Animation/XanimePlayer.cpp
+++ b/source/Game/Animation/XanimePlayer.cpp
@@ -1,16 +1,20 @@
 #include "Game/Animation/XanimePlayer.hpp"
 
-void XanimePlayer::setDefaultAnimation(const char *name) {
+void XanimePlayer::setDefaultAnimation(const char *name)
+{
     const XanimeGroupInfo *defaultAnimation = mResourceTable->getGroupInfo(name);
-    if(mCurrentAnimation == mDefaultAnimation) {
+    if (mCurrentAnimation == mDefaultAnimation) {
         changeAnimation(defaultAnimation);
     }
     mDefaultAnimation = defaultAnimation;
     _7D = true;
 }
 
-void XanimePlayer::changeCurrentAnimation(const XanimeGroupInfo *animation) {
-    if(mCurrentAnimation == animation) return;
+void XanimePlayer::changeCurrentAnimation(const XanimeGroupInfo *animation)
+{
+    if (mCurrentAnimation == animation) {
+        return;
+    }
     mPrevAnimation = mCurrentAnimation;
     mCurrentAnimation = animation;
     updateAfterMovement();

--- a/source/Game/MapObj/ArrowSwitch.cpp
+++ b/source/Game/MapObj/ArrowSwitch.cpp
@@ -1,5 +1,6 @@
 #include "Game/MapObj/ArrowSwitch.hpp"
 #include <cmath>
+#include "math_types.hpp"
 
 namespace {
     const f32 sRotYTargetList[4] = { 0.0f, 90.0f, 180.0f, -90.0f };

--- a/source/Game/MapObj/ArrowSwitchMulti.cpp
+++ b/source/Game/MapObj/ArrowSwitchMulti.cpp
@@ -1,6 +1,7 @@
 #include "Game/MapObj/ArrowSwitchMulti.hpp"
 #include "Game/MapObj/ArrowSwitchMultiHolder.hpp"
 #include "Game/Map/StageSwitch.hpp"
+#include "math_types.hpp"
 
 ArrowSwitchTarget::ArrowSwitchTarget(const char *pName) : NameObj(pName) {
     mJMapIDInfo = nullptr;

--- a/source/Game/MapObj/SpinDriver.cpp
+++ b/source/Game/MapObj/SpinDriver.cpp
@@ -2,6 +2,7 @@
 #include "Game/MapObj/SpinDriverUtil.hpp"
 #include <cstdio>
 #include <cstring>
+#include "math_types.hpp"
 
 SpinDriver::SpinDriver(const char *pName) : LiveActor(pName),
     _8C(nullptr), mShootPath(nullptr), mSpinDriverCamera(nullptr), _98(0, 0, 0, 1), _A8(0, 0, 0, 1), 

--- a/source/Game/Player/MarioActor.cpp
+++ b/source/Game/Player/MarioActor.cpp
@@ -125,7 +125,7 @@ MarioActor::MarioActor(const char *pName) : LiveActor(pName), _1B0(0xFFFFFFFF)
 
     _9D8.zero();
 
-    _9F1 = false;
+    mAlphaEnable = false;
     _9F2 = false;
     _EA4 = false;
     _EA5 = false;
@@ -146,7 +146,7 @@ MarioActor::MarioActor(const char *pName) : LiveActor(pName), _1B0(0xFFFFFFFF)
     _F68.zero();
 
     for (int i = 0; i < 6; i++) {
-        _A28[i] = 0;
+        mModels[i] = nullptr;
     }
 
     _A61 = false;
@@ -614,7 +614,7 @@ void MarioActor::changeGameOverAnimation()
 
 XjointTransform *MarioActor::getJointCtrl(const char *pName) const
 {
-    XanimeCore *pCore = mMarioAnim->_C->mCore;
+    XanimeCore *pCore = mMarioAnim->mXanimePlayer->mCore;
     return pCore->getJointTransform(MR::getJointIndex(this, pName));
 }
 
@@ -740,7 +740,7 @@ void MarioActor::movement()
                 mMario->mDrawStates._2 = true;
             }
         }
-        if (getMovementStates()._0 && !_9F1) {
+        if (getMovementStates()._0 && !mAlphaEnable) {
             if (stack_128.dot(getGravityVec()) < -40.0f) {
                 TVec3f stack_EC(mPosition.translateOpposite(getGravityVec() % 100.0f));
                 TVec3f stack_E0;
@@ -1249,7 +1249,7 @@ void MarioActor::updateSwingAction()
             }
         }
         else if (!getMovementStates()._F && !mMario->isAnimationRun("地上ひねり")) {
-            const char *pLastAnimationName = mMarioAnim->_10->getCurrentAnimationName();
+            const char *pLastAnimationName = mMarioAnim->mXanimePlayerUpper->getCurrentAnimationName();
             if (_3D4 == 4) {
                 if (!mMario->isAnimationRun("ハチスピン")) {
                     didSpinPunch = trySpinPunch();
@@ -1259,7 +1259,7 @@ void MarioActor::updateSwingAction()
                 didSpinPunch = trySpinPunch();
             }
             _974 = 0;
-            if (pLastAnimationName != mMarioAnim->_10->getCurrentAnimationName()) {
+            if (pLastAnimationName != mMarioAnim->mXanimePlayerUpper->getCurrentAnimationName()) {
                 mMario->playSound("パンチ風切り", -1);
             }
         }
@@ -1271,7 +1271,7 @@ void MarioActor::updateSwingAction()
                 }
                 mMario->changeAnimation("ハチスピン空中", (const char *)nullptr);
             }
-            else if (getMovementStates()._A || _9F1) {
+            else if (getMovementStates()._A || mAlphaEnable) {
                 mMario->changeAnimation("サマーソルト", (const char *)nullptr);
             }
             else {
@@ -1309,7 +1309,7 @@ void MarioActor::updateSwingAction()
             mMario->changeAnimation("ハチスピン空中", (const char *)nullptr);
         }
         else {
-            if (getMovementStates()._A || _9F1) {
+            if (getMovementStates()._A || mAlphaEnable) {
                 mMario->changeAnimation("サマーソルト", (const char *)nullptr);    // Summersault
             }
             else {
@@ -1447,7 +1447,7 @@ void MarioActor::incLife(unsigned long amt)
             mHealth = mMaxHealth;
         }
         if (health == 1 && mMarioAnim->isAnimationStop()) {
-            mMarioAnim->_C->changeTrackAnimation(3, "ノーマルウエイト");
+            mMarioAnim->mXanimePlayer->changeTrackAnimation(3, "ノーマルウエイト");
             if (mMario->_970 && strcmp(mMario->_970, "DamageWait")) {
                 mMario->startBas(nullptr, false, 0.0f, 0.0f);
                 setBlink(nullptr);

--- a/source/Game/Player/MarioActorDraw.cpp
+++ b/source/Game/Player/MarioActorDraw.cpp
@@ -1,0 +1,102 @@
+#include "Game/Player/MarioActor.hpp"
+#include "Game/Player/TornadoMario.hpp"
+#include "Game/Player/J3DModelX.hpp"
+#include "Game/Player/DLchanger.hpp"
+#include "Game/Player/ModelHolder.hpp"
+
+void MarioActor::drawMarioModel() const {
+    if(isAllHidden()) {
+        return;
+    }
+
+    if(mTornadoMario) {
+
+        if(mMario->mMovementStates._F) {
+            if(mMario->_544 > 2) {
+                return;
+            }
+        }
+
+        if (
+            !MR::isDead(mTornadoMario) &&
+            (
+                MR::isBckPlaying(mTornadoMario, "MarioTornadoEnd") ||
+                MR::isBckPlaying(mTornadoMario, "MarioTornadoLoop")
+            )
+        ) {
+            return;
+        }
+        
+    }
+
+    switch(mCurrModel) {
+        case 3:
+            return;
+        default:
+            break;
+            return;
+    }
+
+    drawSpinInhibit();
+    drawSphereMask();
+    bool res = drawDarkMask();
+    
+    J3DModelX *model = mModels[mCurrModel];
+    
+    if(res) {
+        model->mFlags._10 = true;
+    }
+    
+    if(!mFlags.mIsHiddenModel) {
+        model->mFlags._1C = false;
+        if(mMario->isStatusActive(0x12)) {
+
+            if(_1A1) {
+                return;
+            }
+
+            mDLchanger->addDL(model);
+
+            MR::showJoint(model, "HandR0");
+            MR::showJoint(model, "HandL0");
+            MR::showJoint(model, "Face0");
+            
+        }
+        else {
+            if(mCurrModel == 4) {
+                model->setDynamicDL(nullptr, 0);
+            }
+            else {
+                model->setDynamicDL(DL[currDL], DLSize);
+            }
+        }
+
+        if(mAlphaEnable) {
+            GXSetAlphaUpdate(1);
+            GXSetDstAlpha(1, 0);
+        }
+        model->setDrawView(0);
+        model->directDraw(nullptr);
+        model->mFlags.clear();
+    }
+
+    if(mMario->isStatusActive(0x12)) {
+        MR::hideJoint(model, "HandR0");
+        MR::hideJoint(model, "HandL0");
+        MR::hideJoint(model, "Face0");
+    }
+
+    drawHand();
+    
+    if(!MR::isHiddenModel(_A5C)) {
+        J3DModelX *cool = (J3DModelX *)MR::getJ3DModel(_A5C);
+        cool->setDynamicDL(DL[currDL], DLSize);
+        cool->directDraw(nullptr);
+    }
+    
+    if(mAlphaEnable) {
+        GXSetAlphaUpdate(0);
+        GXSetDstAlpha(0, 0);
+    }
+    
+}

--- a/source/Game/Player/MarioActorDraw.cpp
+++ b/source/Game/Player/MarioActorDraw.cpp
@@ -1,57 +1,51 @@
-#include "Game/Player/MarioActor.hpp"
-#include "Game/Player/TornadoMario.hpp"
-#include "Game/Player/J3DModelX.hpp"
 #include "Game/Player/DLchanger.hpp"
+#include "Game/Player/J3DModelX.hpp"
+#include "Game/Player/MarioActor.hpp"
 #include "Game/Player/ModelHolder.hpp"
+#include "Game/Player/TornadoMario.hpp"
 
-void MarioActor::drawMarioModel() const {
-    if(isAllHidden()) {
+void MarioActor::drawMarioModel() const
+{
+    if (isAllHidden()) {
         return;
     }
 
-    if(mTornadoMario) {
+    if (mTornadoMario) {
 
-        if(mMario->mMovementStates._F) {
-            if(mMario->_544 > 2) {
+        if (mMario->mMovementStates._F) {
+            if (mMario->_544 > 2) {
                 return;
             }
         }
 
-        if (
-            !MR::isDead(mTornadoMario) &&
-            (
-                MR::isBckPlaying(mTornadoMario, "MarioTornadoEnd") ||
-                MR::isBckPlaying(mTornadoMario, "MarioTornadoLoop")
-            )
-        ) {
+        if (!MR::isDead(mTornadoMario) && (MR::isBckPlaying(mTornadoMario, "MarioTornadoEnd") || MR::isBckPlaying(mTornadoMario, "MarioTornadoLoop"))) {
             return;
         }
-        
     }
 
-    switch(mCurrModel) {
-        case 3:
-            return;
-        default:
-            break;
-            return;
+    switch (mCurrModel) {
+    case 3:
+        return;
+    default:
+        break;
+        return;
     }
 
     drawSpinInhibit();
     drawSphereMask();
     bool res = drawDarkMask();
-    
+
     J3DModelX *model = mModels[mCurrModel];
-    
-    if(res) {
+
+    if (res) {
         model->mFlags._10 = true;
     }
-    
-    if(!mFlags.mIsHiddenModel) {
-        model->mFlags._1C = false;
-        if(mMario->isStatusActive(0x12)) {
 
-            if(_1A1) {
+    if (!mFlags.mIsHiddenModel) {
+        model->mFlags._1C = false;
+        if (mMario->isStatusActive(0x12)) {
+
+            if (_1A1) {
                 return;
             }
 
@@ -60,10 +54,9 @@ void MarioActor::drawMarioModel() const {
             MR::showJoint(model, "HandR0");
             MR::showJoint(model, "HandL0");
             MR::showJoint(model, "Face0");
-            
         }
         else {
-            if(mCurrModel == 4) {
+            if (mCurrModel == 4) {
                 model->setDynamicDL(nullptr, 0);
             }
             else {
@@ -71,7 +64,7 @@ void MarioActor::drawMarioModel() const {
             }
         }
 
-        if(mAlphaEnable) {
+        if (mAlphaEnable) {
             GXSetAlphaUpdate(1);
             GXSetDstAlpha(1, 0);
         }
@@ -80,23 +73,22 @@ void MarioActor::drawMarioModel() const {
         model->mFlags.clear();
     }
 
-    if(mMario->isStatusActive(0x12)) {
+    if (mMario->isStatusActive(0x12)) {
         MR::hideJoint(model, "HandR0");
         MR::hideJoint(model, "HandL0");
         MR::hideJoint(model, "Face0");
     }
 
     drawHand();
-    
-    if(!MR::isHiddenModel(_A5C)) {
+
+    if (!MR::isHiddenModel(_A5C)) {
         J3DModelX *cool = (J3DModelX *)MR::getJ3DModel(_A5C);
         cool->setDynamicDL(mDL[mCurrDL], mDLSize);
         cool->directDraw(nullptr);
     }
-    
-    if(mAlphaEnable) {
+
+    if (mAlphaEnable) {
         GXSetAlphaUpdate(0);
         GXSetDstAlpha(0, 0);
     }
-    
 }

--- a/source/Game/Player/MarioActorDraw.cpp
+++ b/source/Game/Player/MarioActorDraw.cpp
@@ -67,7 +67,7 @@ void MarioActor::drawMarioModel() const {
                 model->setDynamicDL(nullptr, 0);
             }
             else {
-                model->setDynamicDL(DL[currDL], DLSize);
+                model->setDynamicDL(mDL[mCurrDL], mDLSize);
             }
         }
 
@@ -90,7 +90,7 @@ void MarioActor::drawMarioModel() const {
     
     if(!MR::isHiddenModel(_A5C)) {
         J3DModelX *cool = (J3DModelX *)MR::getJ3DModel(_A5C);
-        cool->setDynamicDL(DL[currDL], DLSize);
+        cool->setDynamicDL(mDL[mCurrDL], mDLSize);
         cool->directDraw(nullptr);
     }
     

--- a/source/Game/Player/MarioActorInit.cpp
+++ b/source/Game/Player/MarioActorInit.cpp
@@ -3,14 +3,14 @@
 void MarioActor::initMember()
 {
     _8C = 0;
-    _90 = 0;
+    mDLchanger = nullptr;
     for (int i = 0; i < 0x40; i++) {
         _94[i] = 0;
     }
-    _194 = 0;
-    _198 = 0;
-    _19C = 0;
-    _1A0 = 0;
+    mDL[0] = nullptr;
+    mDL[1] = nullptr;
+    mDLSize = 0;
+    mCurrDL = 0;
     _1A1 = 0;
     _1A4 = 10.0f;
     _1A8 = 0;
@@ -209,7 +209,7 @@ void MarioActor::initMember()
     _988 = 0;
     _984 = 10.0f;
     _989 = 0;
-    _98C = 0;
+    mTornadoMario = nullptr;
     _990 = 0;
     _994 = 0;
     _998 = 0;
@@ -233,14 +233,14 @@ void MarioActor::initMember()
     _9E8 = 0;
     _9EC = 0;
     _9F0 = 0;
-    _9F1 = 0;
+    mAlphaEnable = false;
     _9F2 = 0;
     _9F4.zero();
     _A00 = 0;
     _A04 = 0;
     _A08 = 0;
     _A09 = 0;
-    _A0A = 0;
+    mCurrModel = 0;
     _A0B = 0;
     _A0C = 0;
     _A10 = 0;
@@ -249,7 +249,7 @@ void MarioActor::initMember()
     _A24 = 0;
     _A25 = 0;
     for (int i = 0; i < 6; i++) {
-        _A28[i] = 0;
+        mModels[i] = nullptr;
     }
     _A40 = 0;
     _A44 = 0;

--- a/source/Game/Player/MarioAnimator.cpp
+++ b/source/Game/Player/MarioAnimator.cpp
@@ -68,18 +68,21 @@ bool MarioAnimator::isAnimationStop() const
     return mXanimePlayer->mCurrentAnimation == mXanimePlayer->mDefaultAnimation;
 }
 
-void MarioAnimator::change(const char *name) {
+void MarioAnimator::change(const char *name)
+{
 
-    if(mActor->_B90) return;
+    if (mActor->_B90) {
+        return;
+    }
 
-    if(!isTeresaClear()) {
+    if (!isTeresaClear()) {
         mXanimePlayer->changeAnimation(name);
     }
 
     const char *bck = mXanimePlayer->getCurrentBckName();
-    if(bck) {
+    if (bck) {
         const XanimeGroupInfo *info = mXanimePlayer->mCurrentAnimation;
-        if(info->_18 == 2) {
+        if (info->_18 == 2) {
             f32 arg1 = info->_14, arg2 = info->_10;
             getPlayer()->startBas(bck, false, arg1, arg2);
         }
@@ -95,22 +98,24 @@ void MarioAnimator::change(const char *name) {
     mActor->changeSpecialModeAnimation(name);
     mCurrBck = bck;
     entryCallback(name);
-    
 }
 
-void MarioAnimator::changeUpper(const char *name) {
+void MarioAnimator::changeUpper(const char *name)
+{
     mXanimePlayerUpper->changeAnimation(name);
     _6C = true;
 }
 
-void MarioAnimator::changeDefault(const char *name) {
+void MarioAnimator::changeDefault(const char *name)
+{
     getPlayer()->startBas(nullptr, false, 0.0f, 0.0f);
 
     mXanimePlayer->setDefaultAnimation(name);
 }
 
-void MarioAnimator::changeDefaultUpper(const char *name) {
-    if(name) {
+void MarioAnimator::changeDefaultUpper(const char *name)
+{
+    if (name) {
         mUpperDefaultSet = true;
         mXanimePlayerUpper->setDefaultAnimation(name);
     }

--- a/source/Game/Player/MarioAnimator.cpp
+++ b/source/Game/Player/MarioAnimator.cpp
@@ -35,10 +35,10 @@ void MarioAnimator::init()
     _5C = 0.0f;
     _60.zero();
 
-    _6C = 0;
+    _6C = false;
     _10C = 0;
     _10D = 0;
-    _10E = 0;
+    mUpperDefaultSet = false;
     mCurrBck = 0;
     _118 = 0.0f;
     _70 = 0.0f;
@@ -48,23 +48,24 @@ void MarioAnimator::init()
 
     initCallbackTable();
 
-    _C = new XanimePlayer(MR::getJ3DModel(mActor), mResourceTable);
+    mXanimePlayer = new XanimePlayer(MR::getJ3DModel(mActor), mResourceTable);
 
-    f1("基本");
+    changeDefault("基本");
+    change("基本");
 
-    _C->getCore()->enableJointTransform(MR::getJ3DModelData(mActor));
+    mXanimePlayer->getCore()->enableJointTransform(MR::getJ3DModelData(mActor));
 
-    mActor->mModelManager->mXanimePlayer = _C;
-    _10 = new XanimePlayer(MR::getJ3DModel(mActor), mResourceTable, _C);
+    mActor->mModelManager->mXanimePlayer = mXanimePlayer;
+    mXanimePlayerUpper = new XanimePlayer(MR::getJ3DModel(mActor), mResourceTable, mXanimePlayer);
     changeDefaultUpper("基本");
-    _10->changeAnimation("基本");
-    _10->mCore->shareJointTransform(_C->mCore);
+    mXanimePlayerUpper->changeAnimation("基本");
+    mXanimePlayerUpper->mCore->shareJointTransform(mXanimePlayer->mCore);
     PSMTXCopy(MR::tmpMtxRotYRad(3.14159274101f), _DC.toMtxPtr());
 }
 
 bool MarioAnimator::isAnimationStop() const
 {
-    return _C->mStopAnimation == _C->mDefaultAnimation;
+    return mXanimePlayer->mCurrentAnimation == mXanimePlayer->mDefaultAnimation;
 }
 
 void MarioAnimator::change(const char *name) {
@@ -72,12 +73,12 @@ void MarioAnimator::change(const char *name) {
     if(mActor->_B90) return;
 
     if(!isTeresaClear()) {
-        _C->changeAnimation(name);
+        mXanimePlayer->changeAnimation(name);
     }
 
-    const char *bck = _C->getCurrentBckName();
+    const char *bck = mXanimePlayer->getCurrentBckName();
     if(bck) {
-        const XanimeGroupInfo *info = _C->mStopAnimation; 
+        const XanimeGroupInfo *info = mXanimePlayer->mCurrentAnimation;
         if(info->_18 == 2) {
             f32 arg1 = info->_14, arg2 = info->_10;
             getPlayer()->startBas(bck, false, arg1, arg2);
@@ -95,4 +96,25 @@ void MarioAnimator::change(const char *name) {
     mCurrBck = bck;
     entryCallback(name);
     
+}
+
+void MarioAnimator::changeUpper(const char *name) {
+    mXanimePlayerUpper->changeAnimation(name);
+    _6C = true;
+}
+
+void MarioAnimator::changeDefault(const char *name) {
+    getPlayer()->startBas(nullptr, false, 0.0f, 0.0f);
+
+    mXanimePlayer->setDefaultAnimation(name);
+}
+
+void MarioAnimator::changeDefaultUpper(const char *name) {
+    if(name) {
+        mUpperDefaultSet = true;
+        mXanimePlayerUpper->setDefaultAnimation(name);
+    }
+    else {
+        mUpperDefaultSet = false;
+    }
 }

--- a/source/Game/Player/MarioAnimator.cpp
+++ b/source/Game/Player/MarioAnimator.cpp
@@ -16,7 +16,7 @@ void MarioAnimator::init()
     if (gIsLuigi) {
         luigiAnimations = luigiAnimeSwapTable;
     }
-    _8 = new XanimeResourceTable(MR::getResourceHolder(mActor), marioAnimeTable, marioAnimeAuxTable, marioAnimeOfsTable, &singleAnimeTable[0].parent, &doubleAnimeTable[0].parent, &tripleAnimeTable[0].parent, &quadAnimeTable[0].parent, luigiAnimations);
+    mResourceTable = new XanimeResourceTable(MR::getResourceHolder(mActor), marioAnimeTable, marioAnimeAuxTable, marioAnimeOfsTable, &singleAnimeTable[0].parent, &doubleAnimeTable[0].parent, &tripleAnimeTable[0].parent, &quadAnimeTable[0].parent, luigiAnimations);
 
     _14 = 0;
     _15 = 0;
@@ -39,7 +39,7 @@ void MarioAnimator::init()
     _10C = 0;
     _10D = 0;
     _10E = 0;
-    _114 = 0;
+    mCurrBck = 0;
     _118 = 0.0f;
     _70 = 0.0f;
     _74 = 0;
@@ -48,20 +48,51 @@ void MarioAnimator::init()
 
     initCallbackTable();
 
-    _C = new XanimePlayer(MR::getJ3DModel(mActor), _8);
+    _C = new XanimePlayer(MR::getJ3DModel(mActor), mResourceTable);
 
     f1("Šî–{");
 
     _C->getCore()->enableJointTransform(MR::getJ3DModelData(mActor));
 
     mActor->mModelManager->mXanimePlayer = _C;
-    _10 = new XanimePlayer(MR::getJ3DModel(mActor), _8, _C);
+    _10 = new XanimePlayer(MR::getJ3DModel(mActor), mResourceTable, _C);
     changeDefaultUpper("Šî–{");
     _10->changeAnimation("Šî–{");
     _10->mCore->shareJointTransform(_C->mCore);
     PSMTXCopy(MR::tmpMtxRotYRad(3.14159274101f), _DC.toMtxPtr());
 }
 
-bool MarioAnimator::isAnimationStop() const {
-    return _C->_5C - _C->_60 == 0;
+bool MarioAnimator::isAnimationStop() const
+{
+    return _C->mStopAnimation == _C->mDefaultAnimation;
+}
+
+void MarioAnimator::change(const char *name) {
+
+    if(mActor->_B90) return;
+
+    if(!isTeresaClear()) {
+        _C->changeAnimation(name);
+    }
+
+    const char *bck = _C->getCurrentBckName();
+    if(bck) {
+        const XanimeGroupInfo *info = _C->mStopAnimation; 
+        if(info->_18 == 2) {
+            f32 arg1 = info->_14, arg2 = info->_10;
+            getPlayer()->startBas(bck, false, arg1, arg2);
+        }
+        else {
+            getPlayer()->startBas(bck, false, 0.0f, 0.0f);
+        }
+        mActor->setBlink(bck);
+    }
+    else {
+        getPlayer()->startBas(nullptr, false, 0.0f, 0.0f);
+        mActor->setBlink(nullptr);
+    }
+    mActor->changeSpecialModeAnimation(name);
+    mCurrBck = bck;
+    entryCallback(name);
+    
 }

--- a/source/Game/Player/MarioAnimator.cpp
+++ b/source/Game/Player/MarioAnimator.cpp
@@ -61,3 +61,7 @@ void MarioAnimator::init()
     _10->mCore->shareJointTransform(_C->mCore);
     PSMTXCopy(MR::tmpMtxRotYRad(3.14159274101f), _DC.toMtxPtr());
 }
+
+bool MarioAnimator::isAnimationStop() const {
+    return _C->_5C - _C->_60 == 0;
+}

--- a/source/Game/Player/MarioAnimator.cpp
+++ b/source/Game/Player/MarioAnimator.cpp
@@ -39,7 +39,7 @@ void MarioAnimator::init()
     _10C = 0;
     _10D = 0;
     mUpperDefaultSet = false;
-    mCurrBck = 0;
+    mCurrBck = nullptr;
     _118 = 0.0f;
     _70 = 0.0f;
     _74 = 0;

--- a/source/Game/Screen/CountUpPaneRumbler.cpp
+++ b/source/Game/Screen/CountUpPaneRumbler.cpp
@@ -1,4 +1,5 @@
 #include "Game/Screen/CountUpPaneRumbler.hpp"
+#include "math_types.hpp"
 
 CountUpPaneRumbler::CountUpPaneRumbler(LayoutActor *pActor, const char *pName) {
     mRumbleCalculator = nullptr;


### PR DESCRIPTION
Match `XanimePlayer::setDefaultAnimation`, `XanimePlayer::changeCurrentAnimation`, `MarioActor::drawMarioModel`, `MarioAnimator::isAnimationStop`, `MarioAnimator::changeUpper`, `MarioAnimator::changeDefault`, `MarioAnimator::changeDefaultUpper`.

Also fixed some build errors introduced by 8b348cb0ed199e0abac6a9d76db090f7c69cbe69 related to some files not including the `math_types.hpp` header