### PR TITLE
Add `.gitattributes` to eable line-ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+*.c text
+*.cpp text
+*.h text
+*.hpp text
+*.csv text
+*.json text
+*.md text
+
+archive/* binary
+*.png binary
+


### PR DESCRIPTION
To avoid merge conflicts that result from platform-dependent line-endings, this pull request enables line-ending normalization. 

In commit `0f8946df02fe2376d84b06158c2a3aa7792d3941`, the line endings in `MapObj.csv` are just LF ('\n'). However, in a different commit (`dc86f99802d77c67578a34ff40d0be84dd62f358`), a different contributor committed files with Windows-style line endings (CRLF or "\r\n"), again visible in `MapObj.csv`.

 The differences in line-endings cause unnecessary merge conflicts, so the line-endings should be normalized. 

*Note: line ending normalization will not interfere with SJIS encoding since no multi-byte characters in the encoding contain a CR or LF byte*