### PR TITLE
Enable DWARF v2 Support

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -144,8 +144,8 @@ if not config.non_matching:
 # Tool versions
 config.binutils_tag = "2.42-1"
 config.compilers_tag = "20240706"
-config.dtk_tag = "v1.1.4"
-config.objdiff_tag = "v2.3.3"
+config.dtk_tag = "v1.2.0"
+config.objdiff_tag = "v2.3.4"
 config.sjiswrap_tag = "v1.2.0"
 config.wibo_tag = "0.6.11"
 
@@ -164,10 +164,10 @@ config.ldflags = [
     "-nodefaults",
 ]
 if args.debug:
-    config.ldflags.append("-g")  # Or -gdwarf-2 for Wii linkers
+    config.ldflags.append("-gdwarf-2")
 if args.map:
     config.ldflags.append("-mapunused")
-    # config.ldflags.append("-listclosure") # For Wii linkers
+    config.ldflags.append("-listclosure")
 
 # Use for any additional files that should cause a re-configure when modified
 config.reconfig_deps = []
@@ -360,19 +360,20 @@ cflags_runtime = [
     "-inline auto",
 ]
 
-# REL flags
-cflags_rel = [
-    *cflags_base,
-    "-sdata 0",
-    "-sdata2 0",
-]
+if args.debug:
+    cflags_base.append("-gdwarf-2") #includes runtime
+    cflags_game.append("-gdwarf-2")
+    cflags_nw.append("-gdwarf-2")
+    cflags_sdk.append("-gdwarf-2")
+    cflags_rfl.append("-gdwarf-2")
+    cflags_msl.append("-gdwarf-2")
 
 config.linker_version = "GC/3.0a5"
 
 def GameLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
     return {
         "lib": lib_name,
-        "mw_version": "GC/3.0a3",
+        "mw_version": "GC/3.0a5",
         "cflags": cflags_game,
         "progress_category": "game",
         "objects": objects,
@@ -381,7 +382,7 @@ def GameLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
 def NWLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
     return {
         "lib": lib_name,
-        "mw_version": "GC/3.0a3",
+        "mw_version": "GC/3.0a5",
         "cflags": cflags_nw,
         "progress_category": "nw4r",
         "objects": objects,
@@ -391,7 +392,7 @@ def NWLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
 def SDKLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
     return {
         "lib": lib_name,
-        "mw_version": "GC/3.0a3",
+        "mw_version": "GC/3.0a5",
         "cflags": cflags_sdk,
         "progress_category": "sdk",
         "objects": objects,
@@ -400,7 +401,7 @@ def SDKLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
 def RFLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
     return {
         "lib": lib_name,
-        "mw_version": "GC/3.0a3",
+        "mw_version": "GC/3.0a5",
         "cflags": cflags_rfl,
         "progress_category": "rfl",
         "objects": objects,
@@ -409,7 +410,7 @@ def RFLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
 def MSLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
     return {
         "lib": lib_name,
-        "mw_version": "GC/3.0a3",
+        "mw_version": "GC/3.0a5",
         "cflags": cflags_msl,
         "progress_category": "msl",
         "objects": objects,
@@ -418,7 +419,7 @@ def MSLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
 def TRKLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
     return {
         "lib": lib_name,
-        "mw_version": "GC/3.0a3",
+        "mw_version": "GC/3.0a5",
         "cflags": cflags_base,
         "progress_category": "trk",
         "objects": objects,
@@ -427,7 +428,7 @@ def TRKLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
 def JSysLib(lib_name: str, objects: List[Object]) -> Dict[str, Any]:
     return {
         "lib": lib_name,
-        "mw_version": "GC/3.0a3",
+        "mw_version": "GC/3.0a5",
         "cflags": cflags_base,
         "progress_category": "jsys",
         "objects": objects,

--- a/libs/RVL_SDK/include/revolution/os.h
+++ b/libs/RVL_SDK/include/revolution/os.h
@@ -10,9 +10,6 @@ extern "C" {
 
 #define OSHalt(msg) OSPanic(__FILE__, __LINE__, msg)
 
-typedef s64         OSTime;
-typedef u32         OSTick;
-
 #ifdef __MWERKS__
 u32 __OSBusClock : (0x8000 << 16 | 0x00F8);
 u32 __MEM2End : (0x8000 << 16 | 0x3128);
@@ -60,9 +57,6 @@ u32 OSCachedToPhysical(const void* caddr);
 #define OSRoundUp32B(x) (((u32)(x) + 32 - 1) & ~(32 - 1))
 #define OSRoundDown32B(x) (((u32)(x)) & ~(32 - 1))
 #define OSDiffTick(tick1, tick0) ((s32) (tick1) - (s32) (tick0))
-
-OSTick OSGetTick(void);
-OSTime OSGetTime(void);
 
 u32 OSGetConsoleType(void);
 

--- a/src/Game/Player/Mario.cpp
+++ b/src/Game/Player/Mario.cpp
@@ -145,7 +145,7 @@ Mario::Mario(MarioActor *actor) : MarioModule(actor)
     _38C = -_368;
     _398.setInline(0.0f, 1.0f, 0.0f);
     _344.setInline(1.0f, 0.0f, 0.0f);
-    _74C = 0f;
+    _74C = 0.0f;
     _750 = 0;
     _754 = 0;
     _40C = 0;

--- a/src/Game/Player/MarioActor.cpp
+++ b/src/Game/Player/MarioActor.cpp
@@ -85,7 +85,7 @@ MarioActor::MarioActor(const char *pName) : LiveActor(pName), _1B0(0xFFFFFFFF)
     _3AC = 0;
     _B94 = 0;
     _378 = 0;
-    _6D4 = 0f;
+    _6D4 = 0.0f;
     mSuperKinokoCollected = false;
     mPowerupCollected = false;
     mTransforming = false;
@@ -746,9 +746,9 @@ void MarioActor::movement()
                 TVec3f stack_E0;
                 Triangle *pTmp = mMario->getTmpPolygon();
 
-                if (MR::getFirstPolyOnLineToMap(&stack_E0, pTmp, stack_EC, getGravityVec() % 200f)) {
+                if (MR::getFirstPolyOnLineToMap(&stack_E0, pTmp, stack_EC, getGravityVec() % 200.0f)) {
                     TVec3f stack_D4;
-                    if (MR::vecKillElement(stack_E0.translateOpposite(mPosition), getGravityVec(), &stack_D4) < -5f && pTmp->mParts && !pTmp->mParts->_D4 && getMovementStates()._3E != 1) {
+                    if (MR::vecKillElement(stack_E0.translateOpposite(mPosition), getGravityVec(), &stack_D4) < -5.0f && pTmp->mParts && !pTmp->mParts->_D4 && getMovementStates()._3E != 1) {
                         mPosition = stack_E0;
                         mMario->_130 = mPosition;
                         mMario->stopJump();

--- a/src/Game/Player/MarioInit.cpp
+++ b/src/Game/Player/MarioInit.cpp
@@ -80,7 +80,7 @@ void Mario::initMember()
     _A40.zero();
     _A4C.zero();
     _A58.zero();
-    _A64 = 0f;
+    _A64 = 0.0f;
 
     for (int i = 0; i < 0x20; i++) {
         _A6C[i] = 0;

--- a/src/Game/Player/MarioSwim.cpp
+++ b/src/Game/Player/MarioSwim.cpp
@@ -1014,7 +1014,7 @@ bool MarioSwim::update()
         }
     }
     else if (_19) {
-        AreaObj *obj = MR::getAreaObj("WaterArea", getTrans().translate(getGravityVec() % 100f));
+        AreaObj *obj = MR::getAreaObj("WaterArea", getTrans().translate(getGravityVec() % 100.0f));
         if (obj) {
             TPos3f *followMtx = obj->getFollowMtx();
             if (followMtx) {


### PR DESCRIPTION
3.0a3 has broken DWARF support, so I changed the compiler to 3.0a5 (which seems to match better? 12.13% matched instead of 12.11%), as well as enabling the flag for DWARF v2. I did have to change all float constants without a `.0` to get it to compile, as well as OSTick/OSTime being refined spitting out a bunch of warnings. I also bumped dtk/objdiff versions.

This should allow IDA and Ghidra to actually read DWARF info and import it into a project now, saving work on importing all the structs and types.