### PR TITLE
`FileUtil` decompiled

### DIFF
--- a/config/RMGK01/splits.txt
+++ b/config/RMGK01/splits.txt
@@ -8764,7 +8764,7 @@ Game/Util/DemoUtil.cpp:
 Game/Util/DrawUtil.cpp:
 	.text       start:0x803CBA6C end:0x803CD0E0
 	.ctors      start:0x8052F3A8 end:0x8052F3AC
-	.data       start:0x805E0C20 end:0x805E1030
+	.data       start:0x805E0C20 end:0x805E0FA8
 	.bss        start:0x8060B3C0 end:0x8060B3F0
 	.sdata      start:0x806B2610 end:0x806B2658
 	.sbss       start:0x806B7000 end:0x806B7008
@@ -8779,6 +8779,7 @@ Game/Util/EventUtil.cpp:
 
 Game/Util/FileUtil.cpp:
 	.text       start:0x803CF2A0 end:0x803CFE74
+	.data       start:0x805E0FA8 end:0x805E1030
 	.sdata2     start:0x806C1600 end:0x806C1608
 
 Game/Util/FootPrint.cpp:

--- a/include/Game/Animation/BckCtrl.hpp
+++ b/include/Game/Animation/BckCtrl.hpp
@@ -4,10 +4,6 @@
 
 class XanimePlayer;
 
-namespace {
-    static const char* sDefaultPlayDataName = "_default";
-};
-
 class BckCtrlData { 
 public:
     // some callers inline this and some do not

--- a/include/Game/System/ResourceHolder.hpp
+++ b/include/Game/System/ResourceHolder.hpp
@@ -11,19 +11,6 @@ class J3DModelData;
 
 typedef const char* ArchiveName;
 
-namespace {
-    const char* sModelExt[2] = { ".bdl", ".bmd" };
-    const char* sMotionExt[2] = { ".bck", ".bca" };
-    const char* sBtkExt = ".btk";
-    const char* sBpkExt = ".bpk";
-    const char* sBtpExt = ".btp";
-    const char* sBlkExt = ".blk";
-    const char* sBrkExt = ".brk";
-    const char* sBasExt = ".bas";
-    const char* sBmtExt = ".bmt";
-    const char* sBvaExt = ".bva";
-    const char* sBanmtExt = ".banmt";
-};
 
 class ResourceHolder {
 public:

--- a/include/Game/System/ResourceHolderManager.hpp
+++ b/include/Game/System/ResourceHolderManager.hpp
@@ -27,6 +27,7 @@ public:
     void createResourceHolder(char const *, CreateResourceHolderArgs *);
 
     void createAndAddLayoutHolderStationed(const char *);
+    void removeIfIsEqualHeap(JKRHeap *);
     void createAndAddStationed(const char *);
 
     ResourceHolder* createAndAdd(const char*, JKRHeap *);

--- a/include/Game/Util/FileUtil.hpp
+++ b/include/Game/Util/FileUtil.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Inline.hpp>
+
 #include "revolution.h"
 #include "JSystem/JKernel/JKRDvdRipper.hpp"
 
@@ -7,29 +9,175 @@ class JKRArchive;
 class JKRHeap;
 
 namespace MR { 
-    bool isFileExist(const char *, bool);
-    u32 getFileSize(const char *, bool);
-    s32 convertPathToEntrynumConsideringLanguage(const char *);
-    void* loadToMainRAM(const char *, u8 *, JKRHeap *, JKRDvdRipper::EAllocDirection);
-    void loadAsyncToMainRAM(const char *, u8 *, JKRHeap *, JKRDvdRipper::EAllocDirection);
-    void* mountArchive(const char *, JKRHeap *);
-    void mountAsyncArchive(const char *, JKRHeap *);
-    void mountAsyncArchiveByObjectOrLayoutName(const char *, JKRHeap *);
-    void* receiveFile(const char *);
-    void* receiveArchive(const char *);
+    
+    /// @brief Checks whether a file exists.
+    /// @param pFile Path to the file.
+    /// @param considerLanguage Whether to consider language prefix.
+    /// @return true if file exists, false otherwise.
+    bool isFileExist(const char *pFile, bool considerLanguage) NO_INLINE;
+
+    
+    /// @brief Gets the size of a file.
+    /// @param pFile Path to the file.
+    /// @param considerLanguage Whether to consider language prefix.
+    /// @return Size of the file in bytes.
+    u32 getFileSize(const char *pFile, bool considerLanguage);
+
+    
+    /// @brief Converts a file path to its DVD entry number, considering the language prefix.
+    /// @param pFile Path to the file.
+    /// @return The DVD entry number, or -1 if not found.
+    s32 convertPathToEntrynumConsideringLanguage(const char *pFile);
+
+    
+    /// @brief Loads a file to main RAM synchronously.
+    /// @param pFile Path to the file.
+    /// @param pData Target memory address, or nullptr to allocate.
+    /// @param pHeap Memory heap to use.
+    /// @param allocDir Allocation direction.
+    /// @return Pointer to the loaded data.
+    void* loadToMainRAM(const char *pFile, u8 *pData, JKRHeap *pHeap, JKRDvdRipper::EAllocDirection allocDir);
+
+    
+    /// @brief Requests asynchronous file load to main RAM.
+    /// @param pFile Path to the file.
+    /// @param pData Target memory address, or nullptr to allocate.
+    /// @param pHeap Memory heap to use.
+    /// @param allocDir Allocation direction.
+    void loadAsyncToMainRAM(const char *pFile, u8 *pData, JKRHeap *pHeap, JKRDvdRipper::EAllocDirection allocDir);
+
+    
+    /// @brief Mounts an archive synchronously.
+    /// @param pFile Path to the archive file.
+    /// @param pHeap Memory heap to use.
+    /// @return Pointer to the mounted archive.
+    void* mountArchive(const char *pFile, JKRHeap *pHeap);
+
+    
+    /// @brief Requests asynchronous mounting of an archive.
+    /// @param pFile Path to the archive file.
+    /// @param pHeap Memory heap to use.
+    void mountAsyncArchive(const char *pFile, JKRHeap *pHeap);
+
+    
+    /// @brief Mounts an object or layout archive based on the provided file name.
+    /// @param pFile Object or layout name.
+    /// @param pHeap Memory heap to use (optional). 
+    void mountAsyncArchiveByObjectOrLayoutName(const char *pFile, JKRHeap *pHeap);
+
+    
+    /// @brief Receives a file after it has been asynchronously loaded.
+    /// @param pFile Path to the file.
+    /// @return Pointer to the loaded data.
+    void* receiveFile(const char *pFile);
+
+    
+    /// @brief Receives an archive after it has been asynchronously mounted.
+    /// @param pFile Path to the archive file.
+    /// @return Pointer to the mounted archive. 
+    void* receiveArchive(const char *pFile);
+
+    
+    /// @brief Receives all files that have been requested for loading.
     void receiveAllRequestedFile();
-    void* createAndAddArchive(void *, JKRHeap *, const char *);
-    void getMountedArchiveAndHeap(const char *, JKRArchive **, JKRHeap **);
-    void removeFileConsideringLanguage(const char *);
-    void removeResourceAndFileHolderIfIsEqualHeap(JKRHeap *);
-    void* decompressFileFromArchive(JKRArchive *, const char *, JKRHeap *, int);
-    bool isLoadedFile(const char *);
-    bool isMountedArchive(const char *);
-    bool isLoadedObjectOrLayoutArchive(const char *);
-    void makeFileNameConsideringLanguage(char *, u32, const char *);
-    bool makeObjectArchiveFileName(char *, u32, const char *);
-    bool makeObjectArchiveFileNameFromPrefix(char *, u32, const char *, bool);
-    bool makeLayoutArchiveFileName(char *, u32, const char *);
-    bool makeLayoutArchiveFileNameFromPrefix(char *, u32, const char *, bool);
-    void makeScenarioArchiveFileName(char *, u32, const char *);
+
+    
+    /// @brief Creates and adds an archive from existing memory data.
+    /// @param pData Pointer to the archive data.
+    /// @param pHeap Heap to add the archive to.
+    /// @param pFile File name for identification.
+    /// @return Pointer to the created archive. 
+    void* createAndAddArchive(void *pData, JKRHeap *pHeap, const char *pFile);
+
+    
+    /// @brief Gets the mounted archive and heap for a given file.
+    /// @param pFile Archive file path.
+    /// @param pArchive Output pointer to archive.
+    /// @param pHeap Output pointer to heap.
+    void getMountedArchiveAndHeap(const char *pFile, JKRArchive **pArchive, JKRHeap **pHeap);
+
+    
+    /// @brief Removes a file from memory, considering language prefix.
+    /// @param pFile Path to the file.
+    void removeFileConsideringLanguage(const char *pFile);
+
+    
+    /// @brief Removes resources and file holders from memory if they belong to the specified heap.
+    /// @param heap The heap to check.
+    void removeResourceAndFileHolderIfIsEqualHeap(JKRHeap* heap);
+
+    
+    /// @brief Decompresses a file from an archive into RAM.
+    /// @param archive Archive containing the file.
+    /// @param filename File name within the archive.
+    /// @param heap Heap to allocate memory from.
+    /// @param align Alignment for the allocation.
+    /// @return Pointer to the decompressed file data.
+    void* decompressFileFromArchive(JKRArchive *archive, const char *filename, JKRHeap *heap, int align);
+
+    
+    /// @brief Checks if a file is currently loaded.
+    /// @param pFile File path.
+    /// @return true if the file is loaded, false otherwise.
+    bool isLoadedFile(const char *pFile);
+
+    
+    /// @brief Checks if an archive is currently mounted.
+    /// @param pFile Archive path.
+    /// @return true if the archive is mounted, false otherwise.
+    bool isMountedArchive(const char *pFile);
+
+    
+    /// @brief Checks if an object or layout archive is loaded.
+    /// @param pFile Object or layout name.
+    /// @return true if loaded, false otherwise.
+    bool isLoadedObjectOrLayoutArchive(const char *pFile);
+
+    
+    /// @brief Builds a language-aware file path.
+    /// @param pName Output buffer for the file name.
+    /// @param length Maximum length of the buffer.
+    /// @param pFile Base file path.
+    void makeFileNameConsideringLanguage(char *pName, u32 length, const char *pFile);
+
+    
+    /// @brief Constructs an object archive file name from the provided name.
+    /// @param pName Output buffer for the archive name.
+    /// @param length Buffer length.
+    /// @param pFile Object name.
+    /// @return true if a valid archive was found, false otherwise.
+    bool makeObjectArchiveFileName(char *pName, u32 length, const char *pFile);
+
+    
+    /// @brief Constructs an object archive file name using a prefix.
+    /// @param pName Output buffer for the archive name.
+    /// @param length Buffer length.
+    /// @param pFile Object name.
+    /// @param unused Unused flag.
+    /// @return true if a valid archive was found, false otherwise.
+    bool makeObjectArchiveFileNameFromPrefix(char *pName, u32 length, const char *pFile, bool unused) NO_INLINE;
+
+    
+    /// @brief Constructs a layout archive file name from the provided name.
+    /// @param pName Output buffer for the archive name.
+    /// @param length Buffer length.
+    /// @param pFile Layout name.
+    /// @return true if a valid archive was found, false otherwise.
+    bool makeLayoutArchiveFileName(char *pName, u32 length, const char *pFile);
+
+    
+    /// @brief Constructs a layout archive file name using a prefix, with optional fallback.
+    /// @param pName Output buffer for the archive name.
+    /// @param length Buffer length.
+    /// @param pFile Layout name.
+    /// @param fallback Whether to fall back if none found.
+    /// @return true if a valid archive was found, false otherwise.
+    bool makeLayoutArchiveFileNameFromPrefix(char *pName, u32 length, const char *pFile, bool fallback);
+
+    
+    /// @brief Creates a scenario archive file name from the given stage name.
+    /// @param pName Output buffer for the file name.
+    /// @param length Buffer length.
+    /// @param pFile Stage name.
+    void makeScenarioArchiveFileName(char *pName, u32 length, const char *pFile);
 };

--- a/src/Game/Animation/BckCtrl.cpp
+++ b/src/Game/Animation/BckCtrl.cpp
@@ -1,6 +1,10 @@
 #include "Game/Animation/BckCtrl.hpp"
 #include "Game/Util.hpp"
 
+namespace {
+    static const char* sDefaultPlayDataName = "_default";
+};
+
 void BckCtrl::overWrite(const BckCtrlData &rNew) {
     if (MR::isEqualStringCase(rNew._0, sDefaultPlayDataName)) {
         mDefaultCtrlData = rNew;

--- a/src/Game/System/ResourceHolder.cpp
+++ b/src/Game/System/ResourceHolder.cpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Game/System/ResourceHolder.hpp"
+
+namespace {
+    const char* sModelExt[2] = { ".bdl", ".bmd" };
+    const char* sMotionExt[2] = { ".bck", ".bca" };
+    const char* sBtkExt = ".btk";
+    const char* sBpkExt = ".bpk";
+    const char* sBtpExt = ".btp";
+    const char* sBlkExt = ".blk";
+    const char* sBrkExt = ".brk";
+    const char* sBasExt = ".bas";
+    const char* sBmtExt = ".bmt";
+    const char* sBvaExt = ".bva";
+    const char* sBanmtExt = ".banmt";
+};


### PR DESCRIPTION
- Fixed splits.txt for DrawUtil .data
- Matched all .text
- Added doxygen comments
- Moved ResourceHolder.hpp string definitions to its .cpp file because of unmatching .data