### PR TITLE
Complete `SceneObjHolder`

### DIFF
--- a/include/Game/Scene/SceneObjHolder.hpp
+++ b/include/Game/Scene/SceneObjHolder.hpp
@@ -17,66 +17,167 @@
 #define SceneObj_LiveActorGroupArray 0xE
 #define SceneObj_MovementOnOffGroupHolder 0xF
 #define SceneObj_CaptureScreenActor 0x10
-#define SceneObj_AudCameraWatcher   0x11
-#define SceneObj_AudEffectDirector  0x12
+#define SceneObj_AudCameraWatcher 0x11
+#define SceneObj_AudEffectDirector 0x12
+#define SceneObj_AudBgmConductor 0x13
 #define SceneObj_MarioHolder 0x14
+// #define SceneObj_15 0x15
 #define SceneObj_MirrorCamera 0x16
 #define SceneObj_CameraContext 0x17
-#define SceneObj_IgnorePauseObj 0x18
+#define SceneObj_NameObjGroup 0x18
 #define SceneObj_TalkDirector 0x19
+#define SceneObj_EventSequencer 0x1A
 #define SceneObj_StopSceneController 0x1B
-#define SceneObj_SceneObjMovementCtrl 0x1C
+#define SceneObj_SceneNameObjMovementController 0x1C
+#define SceneObj_ImageEffectSystemHolder 0x1D
+#define SceneObj_BloomEffect 0x1E
+#define SceneObj_BloomEffectSimple 0x1F
+#define SceneObj_ScreenBlurEffect 0x20
+#define SceneObj_DepthOfFieldBlur 0x21
+#define SceneObj_SceneWipeHolder 0x22
 #define SceneObj_PlayerActionGuidance 0x23
+#define SceneObj_ScenePlayingResult 0x24
+#define SceneObj_LensFlareDirector 0x25
+#define SceneObj_FurDrawManager 0x26
 #define SceneObj_PlacementStateChecker 0x27
 #define SceneObj_NamePosHolder 0x28
 #define SceneObj_NPCDirector 0x29
-#define SceneObj_MoviePlayer 0x2B
+#define SceneObj_ResourceShare 0x2A
+#define SceneObj_MoviePlayerSimple 0x2B
+#define SceneObj_WarpPodMgr 0x2C
+#define SceneObj_CenterScreenBlur 0x2D
+#define SceneObj_OdhConverter 0x2E
+#define SceneObj_CometRetryButton 0x2F
 #define SceneObj_AllLiveActorGroup 0x30
+#define SceneObj_CameraDirector 0x31
 #define SceneObj_PlanetGravityManager 0x32
+#define SceneObj_BaseMatrixFollowTargetHolder 0x33
+#define SceneObj_GameSceneLayoutHolder 0x34
+// #define SceneObj_35 0x35
+#define SceneObj_CoinHolder 0x36
 #define SceneObj_PurpleCoinHolder 0x37
 #define SceneObj_CoinRotater 0x38
 #define SceneObj_AirBubbleHolder 0x39
 #define SceneObj_BigFanHolder 0x3A
+#define SceneObj_KarikariDirector 0x3B
+#define SceneObj_StarPieceDirector 0x3C
+#define SceneObj_BegomanAttackPermitter 0x3D
+#define SceneObj_TripodBossAccesser 0x3E
+#define SceneObj_KameckBeamHolder 0x3F
+#define SceneObj_KameckFireBallHolder 0x40
+#define SceneObj_KameckBeamTurtleHolder 0x41
+#define SceneObj_KabokuriFireHolder 0x42
+#define SceneObj_TakoHeiInkHolder 0x43
 #define SceneObj_ShadowControllerHolder 0x44
-#define SceneObj_ShadowVolumeDrawer 0x45
-#define SceneObj_ShadowSurfaceDrawerInit 0x46
+#define SceneObj_ShadowVolumeDrawInit 0x45
+#define SceneObj_ShadowSurfaceDrawInit 0x46
+#define SceneObj_SwingRopeGroup 0x47
+#define SceneObj_PlantStalkDrawInit 0x48
+#define SceneObj_PlantLeafDrawInit 0x49
+#define SceneObj_TrapezeRopeDrawInit 0x4A
+// #define SceneObj_4B 0x4B
 #define SceneObj_VolumeModelDrawInit 0x4C
-#define SceneObj_SpinDrawerPathDrawInit 0x4D
+#define SceneObj_SpinDriverPathDrawInit 0x4D
 #define SceneObj_NoteGroup 0x4E
+#define SceneObj_ClipAreaDropHolder 0x4F
+#define SceneObj_FallOutFieldDraw 0x50
+#define SceneObj_ClipFieldFillDraw 0x51
+// #define SceneObj_52 0x52
+#define SceneObj_ClipAreaHolder 0x53
 #define SceneObj_ArrowSwitchMultiHolder 0x54
+#define SceneObj_ScreenAlphaCapture 0x55
+#define SceneObj_MapPartsRailGuideHolder 0x56
+#define SceneObj_GCapture 0x57
 #define SceneObj_NameObjExecuteHolder 0x58
+#define SceneObj_ElectricRailHolder 0x59
+#define SceneObj_SpiderThread 0x5A
 #define SceneObj_QuakeEffectGenerator 0x5B
+// #define SceneObj_5C 0x5C
 #define SceneObj_HeatHazeDirector 0x5D
+#define SceneObj_BlueChipHolder 0x5E
+#define SceneObj_YellowChipHolder 0x5F
+#define SceneObj_BigBubbleHolder 0x60
 #define SceneObj_EarthenPipeMediator 0x61
+#define SceneObj_WaterAreaHolder 0x62
+#define SceneObj_WaterPlantDrawInit 0x63
+#define SceneObj_OceanHomeMapCtrl 0x64
+#define SceneObj_RaceManager 0x65
+#define SceneObj_GroupCheckManager 0x66
 #define SceneObj_SkeletalFishBabyRailHolder 0x67
-#define SceneObj_SkeletalFishRailHolder 0x68
+#define SceneObj_SkeletalFishBossRailHolder 0x68
+#define SceneObj_WaterPressureBulletHolder 0x69
 #define SceneObj_FirePressureBulletHolder 0x6A
+#define SceneObj_SunshadeMapHolder 0x6B
+#define SceneObj_MiiFacePartsHolder 0x6C
+#define SceneObj_MiiFaceIconHolder 0x6D
+#define SceneObj_FluffWindHolder 0x6E
+#define SceneObj_SphereSelector 0x6F
 #define SceneObj_GalaxyNamePlateDrawer 0x70
+#define SceneObj_CinemaFrame 0x71
+#define SceneObj_BossAccessor 0x72
+#define SceneObj_MiniatureGalaxyHolder 0x73
 #define SceneObj_PlanetMapCreator 0x74
 #define SceneObj_PriorDrawAirHolder 0x75
+#define SceneObj_InformationObserver 0x76
+#define SceneObj_GalaxyMapController 0x77
 #define SceneObj_MoviePlayingSequenceHolder 0x78
+#define SceneObj_PrologueHolder 0x79
+#define SceneObj_StaffRoll 0x7A
+#define SceneObj_COUNT 0x7B
 
 class NameObj;
 
+/// @brief The container for global scene objects.
 class SceneObjHolder {
 public:
+    /// @brief Creates a new `SceneObjHolder`.
     SceneObjHolder();
 
-    NameObj* create(int);
-    NameObj* getObj(int) const;
-    bool isExist(int) const;
-    NameObj* newEachObj(int);
+    /// @brief Creates the requested object, returning the existing instance if it has already been created.
+    /// @param id The index of the object.
+    /// @return The pointer to the object.
+    NameObj* create(int id);
 
-    NameObj* mSceneObjs[0x7B];  // 0x0
+    /// @brief Returns the requested object.
+    /// @param id The index of the object.
+    /// @return The pointer to the object.
+    NameObj* getObj(int id) const;
+
+    /// @brief Determines if the requested object has been created.
+    /// @param id The index of the object.
+    /// @return `true` if the object has been created, `false` otherwise.
+    bool isExist(int id) const;
+
+    /// @brief Creates the requested object.
+    /// @param id The index of the object.
+    /// @return The pointer to the object.
+    NameObj* newEachObj(int id);
+
+private:
+    /// @brief The array of objects.
+    /* 0x00 */ NameObj* mObj[SceneObj_COUNT];
 };
 
 namespace MR {
-    NameObj* createSceneObj(int);
-    SceneObjHolder* getSceneObjHolder();
-    bool isExistSceneObj(int);
+    /// @brief Creates the requested global scene object, returning the existing instance if it has already been created.
+    /// @param id The index of the object.
+    /// @return The pointer to the object.
+    NameObj* createSceneObj(int id);
 
+    /// @brief Returns the container for global scene objects.
+    /// @return The pointer to the container for global scene objects.
+    SceneObjHolder* getSceneObjHolder();
+
+    /// @brief Determines if the requested global scene object has been created.
+    /// @param id The index of the object.
+    /// @return `true` if the object has been created, `false` otherwise.
+    bool isExistSceneObj(int id);
+
+    /// @brief Returns the requested global scene object.
+    /// @param id The index of the object.
+    /// @return The pointer to the object.
     template <class T>
-    inline T getSceneObj(int objID) {
-        return reinterpret_cast<T>(MR::getSceneObjHolder()->getObj(objID));
+    inline T getSceneObj(int id) {
+        return static_cast<T>(MR::getSceneObjHolder()->getObj(id));
     }
-};  // namespace MR
+};

--- a/src/Game/Boss/SkeletalFishBossRailHolder.cpp
+++ b/src/Game/Boss/SkeletalFishBossRailHolder.cpp
@@ -31,11 +31,11 @@ SkeletalFishBossRail* SkeletalFishBossRailHolder::getByID(s32 id) const {
 
 namespace MR {
     SkeletalFishBossRailHolder* getSkeletalFishBossRailHolder() {
-        return MR::getSceneObj<SkeletalFishBossRailHolder*>(SceneObj_SkeletalFishRailHolder);
+        return MR::getSceneObj<SkeletalFishBossRailHolder*>(SceneObj_SkeletalFishBossRailHolder);
     }
 
     void createSkeletalFishBossRailHolder() {
-        MR::createSceneObj(SceneObj_SkeletalFishRailHolder);
+        MR::createSceneObj(SceneObj_SkeletalFishBossRailHolder);
     }
 };
 

--- a/src/Game/LiveActor/ShadowSurfaceDrawer.cpp
+++ b/src/Game/LiveActor/ShadowSurfaceDrawer.cpp
@@ -31,7 +31,7 @@ void ShadowSurfaceDrawInit::initDraw() {
 #endif
 
 ShadowSurfaceDrawer::ShadowSurfaceDrawer(const char *pName) : ShadowDrawer(pName) {
-    MR::createSceneObj(SceneObj_ShadowSurfaceDrawerInit);
+    MR::createSceneObj(SceneObj_ShadowSurfaceDrawInit);
     MR::connectToScene(this, -1, -1, -1, 0x26);
 }
 

--- a/src/Game/LiveActor/ShadowVolumeDrawer.cpp
+++ b/src/Game/LiveActor/ShadowVolumeDrawer.cpp
@@ -15,7 +15,7 @@ ShadowVolumeDrawer::ShadowVolumeDrawer(const char *pName) : ShadowDrawer(pName) 
     mStartDrawShapeOffset = 0.0f;
     mEndDrawShapeOffset = 0.0f;
     mIsCutDropShadow = false;
-    MR::createSceneObj(SceneObj_ShadowVolumeDrawer);
+    MR::createSceneObj(SceneObj_ShadowVolumeDrawInit);
     MR::connectToScene(this, -1, -1, -1, 0x27);
 }
 

--- a/src/Game/MapObj/SpinDriverPathDrawer.cpp
+++ b/src/Game/MapObj/SpinDriverPathDrawer.cpp
@@ -29,7 +29,7 @@ SpinDriverPathDrawer::SpinDriverPathDrawer(SpinDriverShootPath *pShootPath) : Li
     _B8 = 0.0f;
     mFadeScale = 1.0f;
     mMaskLength = 5000.0f;
-    MR::createSceneObj(SceneObj_SpinDrawerPathDrawInit);
+    MR::createSceneObj(SceneObj_SpinDriverPathDrawInit);
 }
 
 #ifdef NON_MATCHING
@@ -69,31 +69,31 @@ void SpinDriverPathDrawInit::initDraw() {
 
 namespace MR {
     void setSpinDriverPathColorNormal() {
-        MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDrawerPathDrawInit)->mOrangeTexture->load(GX_TEXMAP0);
+        MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDriverPathDrawInit)->mOrangeTexture->load(GX_TEXMAP0);
     }
 
     void setSpinDriverPathColorGreen() {
-        MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDrawerPathDrawInit)->mGreenTexture->load(GX_TEXMAP0);
+        MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDriverPathDrawInit)->mGreenTexture->load(GX_TEXMAP0);
     }
     
     void setSpinDriverPathColorPink() {
-        MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDrawerPathDrawInit)->mPinkTexture->load(GX_TEXMAP0);
+        MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDriverPathDrawInit)->mPinkTexture->load(GX_TEXMAP0);
     }
 
     bool isDrawSpinDriverPathAtOpa() {
-        if (!MR::isExistSceneObj(SceneObj_SpinDrawerPathDrawInit)) {
+        if (!MR::isExistSceneObj(SceneObj_SpinDriverPathDrawInit)) {
             return false;
         }
 
-        return MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDrawerPathDrawInit)->mIsPathAtOpa;
+        return MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDriverPathDrawInit)->mIsPathAtOpa;
     }
 
     void onDrawSpinDriverPathAtOpa() {
-        MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDrawerPathDrawInit)->mIsPathAtOpa = true;
+        MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDriverPathDrawInit)->mIsPathAtOpa = true;
     }
 
     void offDrawSpinDriverPathAtOpa() {
-        MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDrawerPathDrawInit)->mIsPathAtOpa = false;
+        MR::getSceneObj<SpinDriverPathDrawInit*>(SceneObj_SpinDriverPathDrawInit)->mIsPathAtOpa = false;
     }
 };
 

--- a/src/Game/Scene/SceneFunction.cpp
+++ b/src/Game/Scene/SceneFunction.cpp
@@ -41,7 +41,7 @@ void SceneFunction::initAfterScenarioSelected() {
 void SceneFunction::initForNameObj() {
     MR::createSceneObj(SceneObj_NameObjExecuteHolder);
     MR::createSceneObj(SceneObj_StopSceneController);
-    MR::createSceneObj(SceneObj_SceneObjMovementCtrl);
+    MR::createSceneObj(SceneObj_SceneNameObjMovementController);
 }
 
 void SceneFunction::initForLiveActor() {

--- a/src/Game/Scene/SceneObjHolder.cpp
+++ b/src/Game/Scene/SceneObjHolder.cpp
@@ -1,91 +1,424 @@
 #include "Game/Scene/SceneObjHolder.hpp"
-#include "Game/AreaObj/AreaObjContainer.hpp"
-#include "Game/Gravity/PlanetGravityManager.hpp"
-#include "Game/Map/PlanetMapCreator.hpp"
-#include "Game/Map/StageSwitch.hpp"
 #include "Game/NameObj/NameObj.hpp"
-#include "Game/NameObj/MovementOnOffGroupHolder.hpp"
-#include "Game/LiveActor/AllLiveActorGroup.hpp"
-#include "Game/LiveActor/ClippingDirector.hpp"
-#include "Game/LiveActor/SensorHitChecker.hpp"
-#include "Game/Scene/StageDataHolder.hpp"
-#include "Game/MapObj.hpp"
-#include "Game/Util.hpp"
-#include <revolution.h>
-
-SceneObjHolder::SceneObjHolder() {
-    for (s32 i = 0; i < 0x7B; i++) {
-        mSceneObjs[i] = 0;
-    }
-}
-
-NameObj* SceneObjHolder::create(int objID) {
-    NameObj* obj = mSceneObjs[objID];
-    if (obj) {
-        return obj;
-    }
-    
-    NameObj* newObj = newEachObj(objID);
-    newObj->initWithoutIter();
-    mSceneObjs[objID] = newObj;
-    return newObj;
-}
-
-NameObj* SceneObjHolder::getObj(int objID) const {
-    return mSceneObjs[objID];
-}
-
-bool SceneObjHolder::isExist(int objID) const {
-    return mSceneObjs[objID] != 0;
-}
-
-namespace MR {
-    NameObj* createSceneObj(int objID) {
-        return MR::getSceneObjHolder()->create(objID);
-    }
-};
 
 /*
-// fill me in as we go
-NameObj* SceneObjHolder::newEachObj(int objID) {
-    switch(objID) {
-        case 0:
-            return new SensorHitChecker("センサー当たり");
-            
-        case 2:
-            return new ClippingDirector();
+#include "Game/AreaObj/AreaObjContainer.hpp"
+#include "Game/Boss/BossAccessor.hpp"
+#include "Game/Boss/SkeletalFishBabyRailHolder.hpp"
+#include "Game/Boss/SkeletalFishBossRailHolder.hpp"
+#include "Game/Boss/TripodBossAccesser.hpp"
+#include "Game/Camera/CameraContext.hpp"
+#include "Game/Camera/CameraDirector.hpp"
+#include "Game/Demo/DemoDirector.hpp"
+#include "Game/Demo/PrologueDirector.hpp"
+#include "Game/Effect/EffectSystem.hpp"
+#include "Game/Enemy/BegomanBase.hpp"
+#include "Game/Enemy/KabokuriFireHolder.hpp"
+#include "Game/Enemy/KameckBeamHolder.hpp"
+#include "Game/Enemy/KarikariDirector.hpp"
+#include "Game/Enemy/TakoHeiInkHolder.hpp"
+#include "Game/GameAudio/AudBgmConductor.hpp"
+#include "Game/GameAudio/AudCameraWatcher.hpp"
+#include "Game/GameAudio/AudEffectDirector.hpp"
+#include "Game/Gravity/PlanetGravityManager.hpp"
+#include "Game/LiveActor/AllLiveActorGroup.hpp"
+#include "Game/LiveActor/ClippingDirector.hpp"
+#include "Game/LiveActor/LiveActorGroupArray.hpp"
+#include "Game/LiveActor/MessageSensorHolder.hpp"
+#include "Game/LiveActor/MirrorCamera.hpp"
+#include "Game/LiveActor/SensorHitChecker.hpp"
+#include "Game/LiveActor/ShadowController.hpp"
+#include "Game/LiveActor/ShadowSurfaceDrawer.hpp"
+#include "Game/LiveActor/ShadowVolumeDrawer.hpp"
+#include "Game/LiveActor/VolumeModelDrawer.hpp"
+#include "Game/Map/Air.hpp"
+#include "Game/Map/CollisionDirector.hpp"
+#include "Game/Map/LightDirector.hpp"
+#include "Game/Map/NamePosHolder.hpp"
+#include "Game/Map/OceanHomeMapCtrl.hpp"
+#include "Game/Map/PlanetMapCreator.hpp"
+#include "Game/Map/QuakeEffectGenerator.hpp"
+#include "Game/Map/RaceManager.hpp"
+#include "Game/Map/SleepControllerHolder.hpp"
+#include "Game/Map/SphereSelector.hpp"
+#include "Game/Map/StageSwitch.hpp"
+#include "Game/Map/SunshadeMapHolder.hpp"
+#include "Game/Map/SwitchWatcherHolder.hpp"
+#include "Game/Map/WaterAreaHolder.hpp"
+#include "Game/Map/WaterPlant.hpp"
+#include "Game/MapObj/AirBubbleHolder.hpp"
+#include "Game/MapObj/ArrowSwitchMultiHolder.hpp"
+#include "Game/MapObj/BigBubbleHolder.hpp"
+#include "Game/MapObj/BigFanHolder.hpp"
+#include "Game/MapObj/ChipHolder.hpp"
+#include "Game/MapObj/ClipAreaDropHolder.hpp"
+#include "Game/MapObj/ClipAreaHolder.hpp"
+#include "Game/MapObj/ClipFieldFillDraw.hpp"
+#include "Game/MapObj/CoinHolder.hpp"
+#include "Game/MapObj/CoinRotater.hpp"
+#include "Game/MapObj/EarthenPipe.hpp"
+#include "Game/MapObj/ElectricRailHolder.hpp"
+#include "Game/MapObj/FallOutFieldDraw.hpp"
+#include "Game/MapObj/FirePressureBulletHolder.hpp"
+#include "Game/MapObj/GCapture.hpp"
+#include "Game/MapObj/MapPartsRailGuideHolder.hpp"
+#include "Game/MapObj/MiniatureGalaxyHolder.hpp"
+#include "Game/MapObj/Note.hpp"
+#include "Game/MapObj/PurpleCoinHolder.hpp"
+#include "Game/MapObj/SpiderThread.hpp"
+#include "Game/MapObj/SpinDriverPathDrawer.hpp"
+#include "Game/MapObj/StarPieceDirector.hpp"
+#include "Game/MapObj/WarpPod.hpp"
+#include "Game/MapObj/WaterPressureBulletHolder.hpp"
+#include "Game/NPC/EventDirector.hpp"
+#include "Game/NPC/MiiFaceIconHolder.hpp"
+#include "Game/NPC/MiiFacePartsHolder.hpp"
+#include "Game/NPC/NPCDirector.hpp"
+#include "Game/NPC/TalkDirector.hpp"
+#include "Game/NameObj/MovementOnOffGroupHolder.hpp"
+#include "Game/NameObj/NameObjExecuteHolder.hpp"
+#include "Game/NameObj/NameObjGroup.hpp"
+#include "Game/Player/GroupChecker.hpp"
+#include "Game/Player/MarioHolder.hpp"
+#include "Game/Player/PlayerEvent.hpp"
+#include "Game/Ride/FluffWind.hpp"
+#include "Game/Ride/PlantLeaf.hpp"
+#include "Game/Ride/PlantStalk.hpp"
+#include "Game/Ride/SwingRope.hpp"
+#include "Game/Ride/Trapeze.hpp"
+#include "Game/Scene/PlacementStateChecker.hpp"
+#include "Game/Scene/SceneDataInitializer.hpp"
+#include "Game/Scene/SceneNameObjMovementController.hpp"
+#include "Game/Scene/ScenePlayingResult.hpp"
+#include "Game/Scene/StageDataHolder.hpp"
+#include "Game/Scene/StopSceneController.hpp"
+#include "Game/Screen/BloomEffect.hpp"
+#include "Game/Screen/BloomEffectSimple.hpp"
+#include "Game/Screen/CaptureScreenDirector.hpp"
+#include "Game/Screen/CenterScreenBlur.hpp"
+#include "Game/Screen/CinemaFrame.hpp"
+#include "Game/Screen/CometRetryButton.hpp"
+#include "Game/Screen/DepthOfFieldBlur.hpp"
+#include "Game/Screen/GalaxyMapController.hpp"
+#include "Game/Screen/GalaxyNamePlateDrawer.hpp"
+#include "Game/Screen/GameSceneLayoutHolder.hpp"
+#include "Game/Screen/HeatHazeEffect.hpp"
+#include "Game/Screen/ImageEffectSystemHolder.hpp"
+#include "Game/Screen/InformationObserver.hpp"
+#include "Game/Screen/LensFlare.hpp"
+#include "Game/Screen/MoviePlayerSimple.hpp"
+#include "Game/Screen/MoviePlayingSequence.hpp"
+#include "Game/Screen/OdhConverter.hpp"
+#include "Game/Screen/PlayerActionGuidance.hpp"
+#include "Game/Screen/SceneWipeHolder.hpp"
+#include "Game/Screen/ScreenAlphaCapture.hpp"
+#include "Game/Screen/ScreenBlurEffect.hpp"
+#include "Game/Screen/StaffRoll.hpp"
+#include "Game/System/GameSystemSceneController.hpp"
+#include "Game/Util/BaseMatrixFollowTargetHolder.hpp"
+#include "Game/Util/FurCtrl.hpp"
+#include "Game/Util/SceneUtil.hpp"
+#include "Game/Util/ShareUtil.hpp"
+*/
 
-        case 8:
-            return new StageDataHolder(MR::getCurrentStageName(), 0, true);
+SceneObjHolder::SceneObjHolder() {
+    for (int i = 0; i < SceneObj_COUNT; i++) {
+        mObj[i] = NULL;
+    }
+}
 
-        case 10:
-            return new StageSwitchContainer();
+NameObj* SceneObjHolder::create(int id) {
+    NameObj* pObj = mObj[id];
 
-        case 13:
-            return new AreaObjContainer("エリアオブジェクトコンテナ管理");
-
-        case 15:
-            return new MovementOnOffGroupHolder("Movementグループ管理");
-
-        case 24:
-            return new NameObjGroup("IgnorePauseNameObj", 0x10);
-
-        case 48:
-            return new AllLiveActorGroup();
-
-        case SceneObj_PlanetGravityManager:
-            return new PlanetGravityManager("重力");
-
-        case 57:
-            return new AirBubbleHolder("空気アワ管理");
-
-        case 88:
-            return new NameObjExecuteHolder(0x1000);
-
-        case 116:
-            return new PlanetMapCreator("惑星クリエイタ");
+    if (pObj != NULL) {
+        return pObj;
     }
 
-    return nullptr;
+    pObj = newEachObj(id);
+    pObj->initWithoutIter();
+
+    mObj[id] = pObj;
+
+    return pObj;
+}
+
+NameObj* SceneObjHolder::getObj(int id) const {
+    return mObj[id];
+}
+
+bool SceneObjHolder::isExist(int id) const {
+    return mObj[id] != NULL;
+}
+
+/*
+NameObj* SceneObjHolder::newEachObj(int id) {
+    switch (id) {
+    case SceneObj_SensorHitChecker:
+        return new SensorHitChecker("センサー当たり");
+    case SceneObj_CollisionDirector:
+        return new CollisionDirector();
+    case SceneObj_ClippingDirector:
+        return new ClippingDirector();
+    case SceneObj_DemoDirector:
+        return new DemoDirector("デモ指揮");
+    case SceneObj_EventDirector:
+        return new EventDirector();
+    case SceneObj_EffectSystem:
+        return new EffectSystem("エフェクトシステム", true);
+    case SceneObj_LightDirector:
+        return new LightDirector();
+    case SceneObj_SceneDataInitializer:
+        return new SceneDataInitializer();
+    case SceneObj_StageDataHolder:
+        return new StageDataHolder(MR::getCurrentStageName(), 0, true);
+    case SceneObj_MessageSensorHolder:
+        return new MessageSensorHolder("システム汎用センサー");
+    case SceneObj_StageSwitchContainer:
+        return new StageSwitchContainer();
+    case SceneObj_SwitchWatcherHolder:
+        return new SwitchWatcherHolder();
+    case SceneObj_SleepControllerHolder:
+        return new SleepControllerHolder();
+    case SceneObj_AreaObjContainer:
+        return new AreaObjContainer("エリアオブジェクトコンテナ管理");
+    case SceneObj_LiveActorGroupArray:
+        return new LiveActorGroupArray("オブジェクトグループ");
+    case SceneObj_MovementOnOffGroupHolder:
+        return new MovementOnOffGroupHolder("Movementグループ管理");
+    case SceneObj_CaptureScreenActor:
+        return new CaptureScreenActor(45, "Indirect");
+    case SceneObj_AudCameraWatcher:
+        return new AudCameraWatcher();
+    case SceneObj_AudEffectDirector:
+        return new AudEffectDirector();
+    case SceneObj_AudBgmConductor:
+        return new AudBgmConductor();
+    case SceneObj_MarioHolder:
+        return new MarioHolder();
+    case SceneObj_MirrorCamera:
+        return new MirrorCamera("鏡用カメラ");
+    case SceneObj_CameraContext:
+        return new CameraContext();
+    case SceneObj_NameObjGroup:
+        return new NameObjGroup("IgnorePauseNameObj", 16);
+    case SceneObj_TalkDirector:
+        return new TalkDirector("会話ディレクター");
+    case SceneObj_EventSequencer:
+        return new EventSequencer();
+    case SceneObj_StopSceneController:
+        return new StopSceneController();
+    case SceneObj_SceneNameObjMovementController:
+        return new SceneNameObjMovementController();
+    case SceneObj_ImageEffectSystemHolder:
+        return new ImageEffectSystemHolder();
+    case SceneObj_BloomEffect:
+        return new BloomEffect("ブルーム");
+    case SceneObj_BloomEffectSimple:
+        return new BloomEffectSimple();
+    case SceneObj_ScreenBlurEffect:
+        return new ScreenBlurEffect("画面ブラー");
+    case SceneObj_DepthOfFieldBlur:
+        return new DepthOfFieldBlur("被写界深度ブラー");
+    case SceneObj_SceneWipeHolder:
+        return new SceneWipeHolder();
+    case SceneObj_PlayerActionGuidance:
+        return new PlayerActionGuidance();
+    case SceneObj_ScenePlayingResult:
+        return new ScenePlayingResult();
+    case SceneObj_LensFlareDirector:
+        return new LensFlareDirector();
+    case SceneObj_FurDrawManager:
+        return new FurDrawManager(64);
+    case SceneObj_PlacementStateChecker:
+        return new PlacementStateChecker("オブジェクト配置状態の監視");
+    case SceneObj_NamePosHolder:
+        return new NamePosHolder();
+    case SceneObj_NPCDirector:
+        return new NPCDirector();
+    case SceneObj_ResourceShare:
+        return new ResourceShare();
+    case SceneObj_MoviePlayerSimple:
+        return new MoviePlayerSimple();
+    case SceneObj_WarpPodMgr:
+        return new WarpPodMgr("ワープポッド管理局");
+    case SceneObj_CenterScreenBlur:
+        return new CenterScreenBlur();
+    case SceneObj_OdhConverter:
+        return new OdhConverter();
+    case SceneObj_CometRetryButton:
+        return new CometRetryButton("コメットリトライボタン");
+    case SceneObj_AllLiveActorGroup:
+        return new AllLiveActorGroup();
+    case SceneObj_CameraDirector:
+        return new CameraDirector("カメラ管理");
+    case SceneObj_PlanetGravityManager:
+        return new PlanetGravityManager("重力");
+    case SceneObj_BaseMatrixFollowTargetHolder:
+        return new BaseMatrixFollowTargetHolder("行列追随先リスト", 256, 256);
+    case SceneObj_GameSceneLayoutHolder:
+        return new GameSceneLayoutHolder();
+    case SceneObj_CoinHolder:
+        return new CoinHolder("コイン管理");
+    case SceneObj_PurpleCoinHolder:
+        return new PurpleCoinHolder();
+    case SceneObj_CoinRotater:
+        return new CoinRotater("コイン回転管理");
+    case SceneObj_AirBubbleHolder:
+        return new AirBubbleHolder("空気アワ管理");
+    case SceneObj_BigFanHolder:
+        return new BigFanHolder();
+    case SceneObj_KarikariDirector:
+        return new KarikariDirector("カリカリディレクター");
+    case SceneObj_StarPieceDirector:
+        return new StarPieceDirector("スターピース指揮");
+    case SceneObj_BegomanAttackPermitter:
+        return new BegomanAttackPermitter("ベーゴマン攻撃許可者");
+    case SceneObj_TripodBossAccesser:
+        return new TripodBossAccesser("三脚ボスアクセサ");
+    case SceneObj_KameckBeamHolder:
+        return new KameckBeamHolder();
+    case SceneObj_KameckFireBallHolder:
+        return new KameckFireBallHolder();
+    case SceneObj_KameckBeamTurtleHolder:
+        return new KameckBeamTurtleHolder();
+    case SceneObj_KabokuriFireHolder:
+        return new KabokuriFireHolder();
+    case SceneObj_TakoHeiInkHolder:
+        return new TakoHeiInkHolder();
+    case SceneObj_ShadowControllerHolder:
+        return new ShadowControllerHolder();
+    case SceneObj_ShadowVolumeDrawInit:
+        return new ShadowVolumeDrawInit();
+    case SceneObj_ShadowSurfaceDrawInit:
+        return new ShadowSurfaceDrawInit("水面影描画初期化");
+    case SceneObj_SwingRopeGroup:
+        return new SwingRopeGroup("スイングロープ描画");
+    case SceneObj_PlantStalkDrawInit:
+        return new PlantStalkDrawInit("植物の茎描画初期化");
+    case SceneObj_PlantLeafDrawInit:
+        return new PlantLeafDrawInit("描画初期化[植物の葉]");
+    case SceneObj_TrapezeRopeDrawInit:
+        return new TrapezeRopeDrawInit("空中ブランコロープ描画");
+    case SceneObj_VolumeModelDrawInit:
+        return new VolumeModelDrawInit();
+    case SceneObj_SpinDriverPathDrawInit:
+        return new SpinDriverPathDrawInit();
+    case SceneObj_NoteGroup:
+        return new NoteGroup();
+    case SceneObj_ClipAreaDropHolder:
+        return new ClipAreaDropHolder();
+    case SceneObj_FallOutFieldDraw:
+        return new FallOutFieldDraw("クリップエリア描画[抜き]");
+    case SceneObj_ClipFieldFillDraw:
+        return new ClipFieldFillDraw("クリップエリア描画[塗りつぶし]");
+    case SceneObj_ClipAreaHolder:
+        return new ClipAreaHolder("クリップエリアホルダー");
+    case SceneObj_ArrowSwitchMultiHolder:
+        return new ArrowSwitchMultiHolder();
+    case SceneObj_ScreenAlphaCapture:
+        return new ScreenAlphaCapture("アルファテクスチャ取り込み");
+    case SceneObj_MapPartsRailGuideHolder:
+        return new MapPartsRailGuideHolder();
+    case SceneObj_GCapture:
+        return new GCapture("Gキャプチャー");
+    case SceneObj_NameObjExecuteHolder:
+        return new NameObjExecuteHolder(4096);
+    case SceneObj_ElectricRailHolder:
+        return new ElectricRailHolder("電撃レール保持");
+    case SceneObj_SpiderThread:
+        return new SpiderThread("クモの巣");
+    case SceneObj_QuakeEffectGenerator:
+        return new QuakeEffectGenerator();
+    case SceneObj_HeatHazeDirector:
+        return new HeatHazeDirector("陽炎制御");
+    case SceneObj_BlueChipHolder:
+        return new ChipHolder("ブルーチップホルダー", 0);
+    case SceneObj_YellowChipHolder:
+        return new ChipHolder("イエローーチップホルダー", 1);
+    case SceneObj_BigBubbleHolder:
+        return new BigBubbleHolder("オオアワホルダー");
+    case SceneObj_EarthenPipeMediator:
+        return new EarthenPipeMediator();
+    case SceneObj_WaterAreaHolder:
+        return new WaterAreaHolder();
+    case SceneObj_WaterPlantDrawInit:
+        return new WaterPlantDrawInit();
+    case SceneObj_OceanHomeMapCtrl:
+        return new OceanHomeMapCtrl();
+    case SceneObj_RaceManager:
+        return new RaceManager();
+    case SceneObj_GroupCheckManager:
+        return new GroupCheckManager("属性グループマネージャー");
+    case SceneObj_SkeletalFishBabyRailHolder:
+        return new SkeletalFishBabyRailHolder("スカルシャークベビーレール管理");
+    case SceneObj_SkeletalFishBossRailHolder:
+        return new SkeletalFishBossRailHolder("スカルシャークボスレール管理");
+    case SceneObj_WaterPressureBulletHolder:
+        return new WaterPressureBulletHolder("ウォータープレッシャー玉ホルダ−");
+    case SceneObj_FirePressureBulletHolder:
+        return new FirePressureBulletHolder("ファイアプレッシャー玉ホルダ−");
+    case SceneObj_SunshadeMapHolder:
+        return new SunshadeMapHolder();
+    case SceneObj_MiiFacePartsHolder:
+        return new MiiFacePartsHolder(128);
+    case SceneObj_MiiFaceIconHolder:
+        return new MiiFaceIconHolder(16, "Miiアイコン保持管理");
+    case SceneObj_FluffWindHolder:
+        return new FluffWindHolder();
+    case SceneObj_SphereSelector:
+        return new SphereSelector();
+    case SceneObj_GalaxyNamePlateDrawer:
+        return new GalaxyNamePlateDrawer();
+    case SceneObj_CinemaFrame:
+        return new CinemaFrame(true);
+    case SceneObj_BossAccessor:
+        return new BossAccessor();
+    case SceneObj_MiniatureGalaxyHolder:
+        return new MiniatureGalaxyHolder();
+    case SceneObj_PlanetMapCreator:
+        return new PlanetMapCreator("惑星クリエイタ");
+    case SceneObj_PriorDrawAirHolder:
+        return new PriorDrawAirHolder();
+    case SceneObj_InformationObserver:
+        return new InformationObserver();
+    case SceneObj_GalaxyMapController:
+        return new GalaxyMapController();
+    case SceneObj_MoviePlayingSequenceHolder:
+        return new MoviePlayingSequenceHolder("ムービー管理保持");
+    case SceneObj_PrologueHolder:
+        return new PrologueHolder("プロローグ保持");
+    case SceneObj_StaffRoll:
+        return new StaffRoll("スタッフロール");
+    default:
+        return NULL;
+    }
 }
 */
+
+namespace MR {
+    NameObj* createSceneObj(int id) {
+        return getSceneObjHolder()->create(id);
+    }
+
+    /*
+    SceneObjHolder* getSceneObjHolder() {
+        return SingletonHolder<GameSystemSceneController>::sInstance->getSceneObjHolder();
+    }
+    */
+
+    /*
+    bool isExistSceneObj(int id) {
+        GameSystemSceneController* pSceneController = SingletonHolder<GameSystemSceneController>::sInstance;
+
+        if (pSceneController == NULL) {
+            return false;
+        }
+
+        if (!pSceneController->isExistSceneObjHolder()) {
+            return false;
+        }
+
+        return getSceneObjHolder()->isExist(id);
+    }
+    */
+};

--- a/src/Game/Screen/MoviePlayingSequence.cpp
+++ b/src/Game/Screen/MoviePlayingSequence.cpp
@@ -120,7 +120,7 @@ MoviePlayingSequence::MoviePlayingSequence(const char *pName, s32 movieType) : L
     mInfo = &sInfoTable[movieType];
     mSubtitles.mCount = 0;
     mPadRumbler = new DemoPadRumbler(MoviePlayingSequence::getMovieName((MovieType)movieType));
-    MR::createSceneObj(SceneObj_MoviePlayer);
+    MR::createSceneObj(SceneObj_MoviePlayerSimple);
     MR::connectToSceneLayoutMovement(this);
     initNerve(&NrvMoviePlayingSequence::HostTypeWait::sInstance);
 

--- a/src/Game/Util/ScreenUtil.cpp
+++ b/src/Game/Util/ScreenUtil.cpp
@@ -5,20 +5,20 @@
 
 namespace MR {
     void startMoviePlayer(const char *pThpFile) {
-        MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayer)->startMovie(pThpFile, false);
+        MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayerSimple)->startMovie(pThpFile, false);
         GameSceneFunction::requestPlayMovieDemo();
     }
 
     void stopMoviePlayer() {
-        MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayer)->stopMovie();
+        MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayerSimple)->stopMovie();
     }
 
     bool isActiveMoviePlayer() {
-        if (!MR::isExistSceneObj(SceneObj_MoviePlayer)) {
+        if (!MR::isExistSceneObj(SceneObj_MoviePlayerSimple)) {
             return false;
         }
 
-        return MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayer)->isMovieActive();
+        return MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayerSimple)->isMovieActive();
     }
 
     bool isMoviePlayerPlaying() {
@@ -26,7 +26,7 @@ namespace MR {
             return false;
         }
 
-        return MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayer)->isMoviePlaying();
+        return MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayerSimple)->isMoviePlaying();
     }
 
     u32 getMovieCurrentFrame() {
@@ -34,14 +34,14 @@ namespace MR {
             return -1;
         }
 
-        return MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayer)->getCurrentFrame();
+        return MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayerSimple)->getCurrentFrame();
     }
 
     u32 getMovieTotalFrame() {
-        return MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayer)->getTotalFrame();
+        return MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayerSimple)->getTotalFrame();
     }
 
     void setMovieVolume(f32 volume, s32 time) {
-        MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayer)->setVolume(volume, time);
+        MR::getSceneObj<MoviePlayerSimple*>(SceneObj_MoviePlayerSimple)->setVolume(volume, time);
     }
 };


### PR DESCRIPTION
`SceneObjHolder::newEachObj`, `MR::getSceneObjHolder`, and `MR::isExistSceneObj` are not yet matching due to missing dependencies used by those functions. However, their theoretical definitions have been provided but commented out. The same applies for the newly specified `#include` directives intended for `SceneObjHolder::newEachObj`.

The remaining global scene object `#define` directives have been provided for convenience.