### PR TITLE
Match `JSUMemoryInputStream` and `JSUMemoryOutputStream` constructors

### DIFF
--- a/libs/JSystem/include/JSystem/JSupport/JSUMemoryInputStream.hpp
+++ b/libs/JSystem/include/JSystem/JSupport/JSUMemoryInputStream.hpp
@@ -4,12 +4,13 @@
 
 class JSUMemoryInputStream : public JSURandomInputStream  {
 public:
-    JSUMemoryInputStream() : JSURandomInputStream() {
-        
+    JSUMemoryInputStream(const void* pBuffer, s32 size) :
+        JSURandomInputStream()
+    {
+        setBuffer(pBuffer, size);
     }
 
     virtual ~JSUMemoryInputStream();
-
     virtual u32 readData(void *, s32);
     virtual s32 getLength() const;
     virtual s32 getPosition() const;

--- a/libs/JSystem/include/JSystem/JSupport/JSUMemoryOutputStream.hpp
+++ b/libs/JSystem/include/JSystem/JSupport/JSUMemoryOutputStream.hpp
@@ -4,8 +4,10 @@
 
 class JSUMemoryOutputStream : public JSURandomOutputStream {
 public:
-    inline JSUMemoryOutputStream() {
-        
+    JSUMemoryOutputStream(void* pBuffer, s32 size) :
+        JSURandomOutputStream()
+    {
+        setBuffer(pBuffer, size);
     }
 
     virtual ~JSUMemoryOutputStream();

--- a/libs/JSystem/include/JSystem/JSupport/JSURandomInputStream.hpp
+++ b/libs/JSystem/include/JSystem/JSupport/JSURandomInputStream.hpp
@@ -2,11 +2,9 @@
 
 #include "JSystem/JSupport/JSUInputStream.hpp"
 
-enum JSUStreamSeekFrom;
-
 class JSURandomInputStream : public JSUInputStream {
 public:
-    inline JSURandomInputStream();
+    JSURandomInputStream() {}
 
     virtual ~JSURandomInputStream();
 

--- a/libs/JSystem/include/JSystem/JSupport/JSURandomOutputStream.hpp
+++ b/libs/JSystem/include/JSystem/JSupport/JSURandomOutputStream.hpp
@@ -4,7 +4,7 @@
 
 class JSURandomOutputStream : public JSUOutputStream {
 public:
-    inline JSURandomOutputStream();
+    JSURandomOutputStream() {}
 
     virtual s32 writeData(const void *, s32) = 0;
     virtual s32 getLength() const = 0;

--- a/src/Game/System/ConfigDataHolder.cpp
+++ b/src/Game/System/ConfigDataHolder.cpp
@@ -25,8 +25,7 @@ s32 ConfigDataCreateChunk::serialize(u8 *pData, u32 len) const {
 
 s32 ConfigDataCreateChunk::deserialize(const u8 *pData, u32 len) {
     initializeData();
-    JSUMemoryInputStream stream;
-    stream.setBuffer(pData, len);
+    JSUMemoryInputStream stream = JSUMemoryInputStream(pData, len);
     u8 data;
     stream.read(&data, 1);
     mData = data != 0;

--- a/src/Game/System/ConfigDataHolder.cpp
+++ b/src/Game/System/ConfigDataHolder.cpp
@@ -16,8 +16,7 @@ u32 ConfigDataCreateChunk::getSignature() const {
 }
 
 s32 ConfigDataCreateChunk::serialize(u8 *pData, u32 len) const {
-    JSUMemoryOutputStream stream;
-    stream.setBuffer(pData, len);
+    JSUMemoryOutputStream stream = JSUMemoryOutputStream(pData, len);
     u8 data = -(mData != 0); 
     stream.write(&data, 1);
     return stream.mPosition;

--- a/src/Game/System/ConfigDataMii.cpp
+++ b/src/Game/System/ConfigDataMii.cpp
@@ -54,8 +54,7 @@ s32 ConfigDataMii::serialize(u8 *pData, u32 len) const {
 
 s32 ConfigDataMii::deserialize(const u8 *pData, u32 len) {
     initializeData();
-    JSUMemoryInputStream stream;
-    stream.setBuffer(pData, len);
+    JSUMemoryInputStream stream = JSUMemoryInputStream(pData, len);
     u8 stack_8;
     stream.read(&stack_8, 1);
     _4 = stack_8;

--- a/src/Game/System/ConfigDataMii.cpp
+++ b/src/Game/System/ConfigDataMii.cpp
@@ -42,8 +42,7 @@ u32 ConfigDataMii::getSignature() const {
 }
 
 s32 ConfigDataMii::serialize(u8 *pData, u32 len) const {
-    JSUMemoryOutputStream stream;
-    stream.setBuffer(pData, len);
+    JSUMemoryOutputStream stream = JSUMemoryOutputStream(pData, len);
     u8 stack_9 = _4;
     stream.write(&stack_9, 1);
     stream.write(mBuffer, 8);

--- a/src/Game/System/ConfigDataMisc.cpp
+++ b/src/Game/System/ConfigDataMisc.cpp
@@ -66,8 +66,7 @@ s32 ConfigDataMisc::serialize(u8 *pData, u32 len) const {
 
 s32 ConfigDataMisc::deserialize(const u8 *pData, u32 len) {
     initializeData();
-    JSUMemoryInputStream stream;
-    stream.setBuffer(pData, len);
+    JSUMemoryInputStream stream = JSUMemoryInputStream(pData, len);
     u8 stack_8;
     stream.read(&stack_8, 1);
     mData = stack_8;

--- a/src/Game/System/ConfigDataMisc.cpp
+++ b/src/Game/System/ConfigDataMisc.cpp
@@ -55,8 +55,7 @@ u32 ConfigDataMisc::getSignature() const {
 }
 
 s32 ConfigDataMisc::serialize(u8 *pData, u32 len) const {
-    JSUMemoryOutputStream stream;
-    stream.setBuffer(pData, len);
+    JSUMemoryOutputStream stream = JSUMemoryOutputStream(pData, len);
     u8 stack_8 = mData;
     stream.write(&stack_8, 1);
     OSTime stack_10 = mLastModified;


### PR DESCRIPTION
The following functions now match as a result of these changes:

- `ConfigDataCreateChunk::deserialize`
- `ConfigDataCreateChunk::serialize`
- `ConfigDataMii::deserialize`
- `ConfigDataMii::serialize`
- `ConfigDataMisc::deserialize`
- `ConfigDataMisc::serialize`