### PR TITLE
Fix behavioral mismatch in TripodBoss::initLegIKPlacement

### DIFF
--- a/libs/JSystem/include/JSystem/JGeometry/TVec.hpp
+++ b/libs/JSystem/include/JSystem/JGeometry/TVec.hpp
@@ -150,14 +150,12 @@ namespace JGeometry {
         }
 
         // Can't be NO_INLINE (gets inlined in DiskGravity::DiskGravity())
-        TVec3(f32 _x, f32 _y, f32 _z) {
+        template<typename T>
+        TVec3(T _x, T _y, T _z) {
             x = _x;
             y = _y;
             z = _z;
         }
-
-        template<typename T>
-        TVec3(T, T, T);
         
         TVec3(f32 xz, f32 _y) {
             x = xz;

--- a/libs/JSystem/include/JSystem/JMath/JMATrigonometric.hpp
+++ b/libs/JSystem/include/JSystem/JMath/JMATrigonometric.hpp
@@ -26,28 +26,25 @@ namespace JMath {
         f32 sinShort(s8 v) const { return table[static_cast<u8>(v) >> 3].a1; }
         f32 cosShort(s8 v) const { return table[static_cast<u8>(v) >> 3].b1; }
 
-        inline f32 sinLap(f32 v)
+        inline f32 sinLapRad(f32 v)
         {
             if (v < 0.0f) {
-                f32 tmp = v * -LEN / TWO_PI;
+                f32 tmp = v * (-LEN / TWO_PI);
                 return -table[(u16)tmp & LEN - 1].a1;
             }
             else {
-                f32 tmp = v * LEN / TWO_PI;
+                f32 tmp = v * (LEN / TWO_PI);
                 return table[(u16)tmp & LEN - 1].a1;
             }
         }
 
-        inline f32 sinLap2(f32 v)
-        {
-            if (v < 0.0f) {
-                f32 tmp = v * -LEN;
-                return -table[(u16)tmp & LEN - 1].a1;
+        inline f32 cosLapRad(f32 v) {
+            if(v < 0.0f) {
+                v = -v;
             }
-            else {
-                f32 tmp = v * LEN;
-                return table[(u16)tmp & LEN - 1].a1;
-            }
+            
+            v *= (LEN / TWO_PI);
+            return table[(u16)v & LEN - 1].b1; 
         }
 
         inline f32 cosLap(f32 v) {
@@ -59,12 +56,8 @@ namespace JMath {
     
             return table[(u16)v & LEN - 1].b1;
         }
+        
         inline f32 get(f32 v) { return table[(u16)v & LEN - 1].b1; }
-
-        inline f32 getMult(f32 v) { 
-            v *= LEN;
-            return table[(u16)v & LEN - 1].b1; 
-        }
     };
 
     template <s32 Len, typename T>

--- a/src/Game/Boss/TripodBoss.cpp
+++ b/src/Game/Boss/TripodBoss.cpp
@@ -28,7 +28,7 @@ namespace {
     static s32 sHeadExplodeSeTiming;
 
     static TVec3f sPowerStarOffset(0.0f, 3200.0f, 0.0f);
-    static TVec3f sAppearStarPieceOffset(0.0, 3600.0f, 0.0f);
+    static TVec3f sAppearStarPieceOffset(0.0f, 3600.0f, 0.0f);
     static TVec3f sEndMarioPosition(0.0f, 2160.0f, 1260.0f);
 };
 
@@ -164,10 +164,9 @@ void TripodBoss::initLeg(const JMapInfoIter &rIter) {
     }
 }
 
-// https://decomp.me/scratch/UDA4k
 void TripodBoss::initLegIKPlacement() {
     f32 temp618 = _618;
-    f32 v5 = MR::speedySqrtf((1.0f - (_618 * _618)));
+    f32 v5 = MR::speedySqrtf((1.0f - (temp618 * temp618)));
 
     TVec3f v29(mMovableArea->mBaseAxis);
     TVec3f v28(mMovableArea->mFront);
@@ -179,50 +178,38 @@ void TripodBoss::initLegIKPlacement() {
 
     f32 ONEPOINTFIVEPI = 2.0943952f;
     for (u32 i = 0; i < 3; i++) {
+        u32 &rI = i;
         f32 cur = -(f32)i * ONEPOINTFIVEPI;
-        f32 v8 = ((0.5f * ONEPOINTFIVEPI) + cur);
-        f32 v9 = JMath::sSinCosTable.sinLap2(v8);
+        f32 initAngle = ((0.5f * ONEPOINTFIVEPI) + cur);
+        f32 x = JMath::sSinCosTable.sinLapRad(initAngle);
+        f32 z = JMath::sSinCosTable.cosLapRad(initAngle);
+        
+        TVec3f legDirShadow;
+        legDirShadow.x = x;
+        legDirShadow.y = 0.0f;
+        legDirShadow.z = z;
 
-        if (v8 < 0.0f) {
-            v8 = -v8;
-        }
+        TVec3f j(0.0f, 1.0f, 0.0f);
+        
+        TVec3f legDir = legDirShadow.multiplyOperatorInline(_610).translate(j.multiplyOperatorInline(_614));
 
-        TVec3f v26;
-        v26.x = v9;
-        v26.y = 0.0f;
-        f32 v10 = JMath::sSinCosTable.getMult(v8);
-        f32 v11 = v10;
-        v26.z = v10;
-        TVec3f v25(0.0f, 1.0f, 0.0f);
-        f32 val = _614;
-        TVec3f v19(v25);
-        v19 *= val;
-        f32 other_val = _610;
-        TVec3f v20(v26);
-        v20 *= other_val;
-        TVec3f v24(v20);
-        v24 += v19;
-        getLeg(i)->setIKParam(_608, _60C, v24, v26, v25);
+        getLeg(rI)->setIKParam(_608, _60C, legDir, legDirShadow, j);
+        
         TVec3f* center = &mMovableArea->mCenter;
-        TVec3f v15(v28);
-        v15 *= v11;
-        TVec3f v16(v27);
-        v16 *= v9;
-        TVec3f v17(v29);
-        v17 += v16;
-        TVec3f v18(v17);
-        v18 += v15;
-        TVec3f v23(v18);
-        v23 += *center;
+
+        TVec3f v23 = v29.translate(v27.multiplyOperatorInline(x)).translate(v28.multiplyOperatorInline(z)).translate(*center);
+
         TVec3f v22;
         mMovableArea->calcLandingNormal(&v22, v23);
+        
         TVec3f v21;
         mMovableArea->calcLandingFront(&v21, v23);
-        getStepPoint(i)->setStepPosition(v23);
-        getStepPoint(i)->setStepNormal(v22);
-        getStepPoint(i)->setStepFront(v21);
-        getLeg(i)->setStepTarget(getStepPoint(i));
-        getLeg(i)->setWait();
+
+        getStepPoint(rI)->setStepPosition(v23);
+        getStepPoint(rI)->setStepNormal(v22);
+        getStepPoint(rI)->setStepFront(v21);
+        getLeg(rI)->setStepTarget(getStepPoint(rI));
+        getLeg(rI)->setWait();
     }
 }
 

--- a/src/Game/Boss/TripodBossShell.cpp
+++ b/src/Game/Boss/TripodBossShell.cpp
@@ -28,7 +28,7 @@ void TripodBossShell::init(const JMapInfoIter &rIter) {
     initModelManagerWithAnm("TripodBossShell", nullptr, false);
     MR::connectToScene(this, 0x23, 0xB, 0x1F, -1);
     initHitSensor(2);
-    MR::addHitSensorMapObj(this, "body", 0x10, 900.0f, TVec3f(0.0, 300.0f, 0.0f));
+    MR::addHitSensorMapObj(this, "body", 0x10, 900.0f, TVec3f(0.0f, 300.0f, 0.0f));
     MR::addHitSensor(this, "killer_terget", 0x52, 8, 900.0f * mScale.x, TVec3f(0.0f, 0.0f, 0.0f));
     MR::initCollisionParts(this, "TripodBossShell", getSensor("killer_terget"), nullptr);
     initSound(4, false);

--- a/src/Game/MapObj/WaveFloatingForce.cpp
+++ b/src/Game/MapObj/WaveFloatingForce.cpp
@@ -23,7 +23,7 @@ void WaveFloatingForce::update() {
 
 #ifdef NON_MATCHING
 f32 WaveFloatingForce::getCurrentValue() const {
-    return _8 * JMath::sSinCosTable.sinLap(_C);
+    return _8 * JMath::sSinCosTable.sinLapRad(_C);
 }
 #endif
 


### PR DESCRIPTION
The only behavioural change is replacing `sSinCosTable.sinLap2` and `sSinCosTable.getMult` with `sSinCosTable.sinLapRad` and `sSinCosTable.cosLapRad`. The rest of the changes are renaming variables and getting the assembly to match more closely.