### PR TITLE
Match AudRemixMgr, mostly match AudRemixSequencer

### DIFF
--- a/config/RMGK01/splits.txt
+++ b/config/RMGK01/splits.txt
@@ -458,7 +458,7 @@ Game/AudioLib/AudBgmRhythmStrategy.cpp:
 
 Game/AudioLib/AudBgmSetting.cpp:
 	.text       start:0x80030A74 end:0x80030BA0
-	.rodata     start:0x8052FA48 end:0x80530A68
+	.rodata     start:0x8052FA48 end:0x80530A60
 
 Game/AudioLib/AudBgmVolumeController.cpp:
 	.text       start:0x80030BA0 end:0x80030E0C
@@ -466,7 +466,7 @@ Game/AudioLib/AudBgmVolumeController.cpp:
 
 Game/AudioLib/AudEffector.cpp:
 	.text       start:0x80030E0C end:0x80030F24
-	.data       start:0x80566170 end:0x80566398
+	.data       start:0x80566170 end:0x805661F0
 	.sdata2     start:0x806B8098 end:0x806B80A0
 
 Game/AudioLib/AudFader.cpp:
@@ -489,7 +489,8 @@ Game/AudioLib/AudRemixMgr.cpp:
 
 Game/AudioLib/AudRemixSequencer.cpp:
 	.text       start:0x80031544 end:0x80031A30
-	.data       start:0x80566398 end:0x80566790
+	.rodata     start:0x80530A60 end:0x80530A68
+	.data       start:0x805661F0 end:0x805663D8
 	.sdata2     start:0x806B80A8 end:0x806B80B8
 
 Game/AudioLib/AudSceneMgr.cpp:
@@ -501,7 +502,7 @@ Game/AudioLib/AudSceneMgr.cpp:
 Game/AudioLib/AudSeStrategy.cpp:
 	.text       start:0x80032454 end:0x800327BC
 	.ctors      start:0x8052E838 end:0x8052E83C
-	.data       start:0x80566790 end:0x805667B8
+	.data       start:0x805663D8 end:0x805667B8
 	.bss        start:0x8060A500 end:0x8060A510
 	.sdata2     start:0x806B80B8 end:0x806B80C0
 

--- a/configure.py
+++ b/configure.py
@@ -653,7 +653,7 @@ config.libs = [
             Object(NonMatching, "Game/AudioLib/AudLimitedSound.cpp"),
             Object(NonMatching, "Game/AudioLib/AudMeNameConverter.cpp"),
             Object(NonMatching, "Game/AudioLib/AudMicWrap.cpp"),
-            Object(NonMatching, "Game/AudioLib/AudRemixMgr.cpp"),
+            Object(Matching, "Game/AudioLib/AudRemixMgr.cpp"),
             Object(NonMatching, "Game/AudioLib/AudRemixSequencer.cpp"),
             Object(NonMatching, "Game/AudioLib/AudSceneMgr.cpp"),
             Object(NonMatching, "Game/AudioLib/AudSeStrategy.cpp"),

--- a/include/Game/AudioLib/AudRemixMgr.hpp
+++ b/include/Game/AudioLib/AudRemixMgr.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Game/AudioLib/AudSoundObject.hpp"
+#include "Game/AudioLib/AudRemixSequencer.hpp"
+
+class JKRHeap;
+struct RemixTrack {
+    s32 _0;
+    u32 *_4;
+};
+
+struct RemixNoteGroupData {
+    /* 0x0  */ s32 mIndex;
+    /* 0x4  */ s32 mTrackCount;
+    /* 0x8  */ u32 mNoteCount;
+    u32 *_C;
+    /* 0x10 */ RemixTrack *mRemixTracks;
+};
+
+class AudRemixMgr {
+public:
+    AudRemixMgr(JKRHeap *pHeap);
+    void init();
+    void update();
+    void setRemixSeqResource(void *ptr);
+    RemixNoteGroupData *getRemixNoteGroupDataFromMelodyNo(s32 melodyNo) const;
+
+    /* 0x0  */ JKRHeap *mHeap;
+    /* 0x4  */ RemixNoteGroupData *mGroups;
+    /* 0x8  */ s32 mGroupCount;
+    /* 0xC  */ AudSoundObject *mSoundObj;
+    /* 0x10 */ AudRemixSequencer *mRemixSeq;
+};

--- a/include/Game/AudioLib/AudRemixSequencer.hpp
+++ b/include/Game/AudioLib/AudRemixSequencer.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#include <revolution/types.h>
+#include "Game/GameAudio/AudTalkSoundData.hpp"
+
+struct RemixNoteTrackData {
+    u32 _0;
+};
+
+struct RemixNoteData {
+    s32 _0;
+    s32 _4;
+    s32 _8;
+    s32 _C;
+};
+
+class AudRmxSeqNoteOnTimer {
+public:
+    AudRmxSeqNoteOnTimer();
+    void initData();
+    void setData(const RemixNoteTrackData*, const RemixNoteData*);
+    bool update(f32);
+    JAISoundID getFreeSeID();
+    f32 _0;
+    f32 _4;
+    const RemixNoteData *_8;
+    const RemixNoteTrackData *_C;
+};
+
+class AudRemixSequencer {
+public:
+    AudRemixSequencer();
+    void initNoteOnBuff();
+    void update();
+    void setTempo(f32) NO_INLINE;
+    AudRmxSeqNoteOnTimer *newNoteOnTimer();
+    void addNoteData(const RemixNoteTrackData*, const RemixNoteData*);
+    AudRmxSeqNoteOnTimer _0[0x20];
+    f32 _200;
+    f32 _204;
+};

--- a/include/Game/AudioLib/AudSoundNameConverter.hpp
+++ b/include/Game/AudioLib/AudSoundNameConverter.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "Game/GameAudio/AudTalkSoundData.hpp"
+
+class JAISoundID;
+
+class AudSoundNameConverter
+{
+public:
+    JAISoundID getSoundID(const char *) const;
+    JAISoundID getSoundID(const char *, u32) const;
+};

--- a/include/Game/AudioLib/AudSoundObject.hpp
+++ b/include/Game/AudioLib/AudSoundObject.hpp
@@ -11,8 +11,8 @@ public:
     AudSoundObject(TVec3f *, u8, JKRHeap *);
     virtual ~AudSoundObject();
 
-    virtual void startSound(JAISoundID);
-    virtual void startLevelSound(JAISoundID);
+    virtual JAISoundHandle *startSound(JAISoundID);
+    virtual JAISoundHandle *startLevelSound(JAISoundID);
 
     void addToSoundObjHolder();
     void setTrans(TVec3f *);
@@ -41,7 +41,6 @@ public:
     void modifyLimitedSound_Takezawa(JAISoundID);
     void modifySe_Gohara(JAISoundHandle *, s32, s32);
 
-    u8 _18[0x18];
     u32 _30;
     u32 _34;
     u32 _38;

--- a/include/Game/AudioLib/AudWrap.hpp
+++ b/include/Game/AudioLib/AudWrap.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "Game/AudioLib/AudBgm.hpp"
+#include "Game/AudioLib/AudRemixSequencer.hpp"
+#include "Game/AudioLib/AudSoundObject.hpp"
 #include "Game/AudioLib/AudSystem.hpp"
 #include <revolution.h>
 
@@ -25,4 +27,8 @@ public:
     static void setNextIdStageBgm(u32);
 
     static void startStageBgm(u32, bool);
+
+    static AudRemixSequencer *getRemixSequencer();
+    static AudSoundObject *getRemixSeqObject();
+    static AudSoundObject *getSystemSeObject();
 };

--- a/include/Game/GameAudio/AudTalkSoundData.hpp
+++ b/include/Game/GameAudio/AudTalkSoundData.hpp
@@ -4,7 +4,11 @@
 
 class JAISoundID {
 public:
-    JAISoundID(u32);
+    JAISoundID() {
 
-    u32 mID;    // 0x0
+    };
+    JAISoundID(u32);
+    JAISoundID(JAISoundID const& other) { mID = other.mID; };
+
+    /* 0x0 */ u32 mID;
 };

--- a/include/Game/SingletonHolder.hpp
+++ b/include/Game/SingletonHolder.hpp
@@ -20,3 +20,24 @@ public:
 
 template<typename T>
 T* SingletonHolder<T>::sInstance;
+
+template<typename T>
+class AudSingletonHolder
+{
+public:
+    static T* get() {
+        return sInstance;
+    }
+
+    static void set(T *p) {
+        sInstance = p;
+    }
+
+    static bool exists() {
+        return sInstance != nullptr;
+    }
+
+    static T* sInstance;
+};
+template<typename T>
+T* AudSingletonHolder<T>::sInstance;

--- a/libs/JSystem/include/JSystem/JAudio2/JAISoundHandles.hpp
+++ b/libs/JSystem/include/JSystem/JAudio2/JAISoundHandles.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "Game/GameAudio/AudTalkSoundData.hpp"
+#include "Game/AudioLib/AudSoundObject.hpp"
+
+class JAISoundHandle;
+
+class JAISoundHandles
+{
+public:
+    u32 *getHandleSoundID(JAISoundID); // exact return type currently unknown
+
+    /* 0x0 */ JAISoundHandle *mHandles;
+    u32 _4;
+};

--- a/libs/JSystem/include/JSystem/JAudio2/JAUSoundObject.hpp
+++ b/libs/JSystem/include/JSystem/JAudio2/JAUSoundObject.hpp
@@ -1,14 +1,13 @@
 #pragma once
 
+#include "JSystem/JAudio2/JAISoundHandles.hpp"
 #include "JSystem/JGeometry/TVec.hpp"
 #include "Game/GameAudio/AudTalkSoundData.hpp"
 
 class JAISoundHandle;
 
-class JAUSoundObject {
+class JAUSoundObject : public JAISoundHandles {
 public:
-    JAISoundHandle *mHandles;   // 0x0
-    u32 _4;
 
     JAUSoundObject();
     ~JAUSoundObject();
@@ -16,9 +15,9 @@ public:
     virtual void process();
     virtual void dispose();
     virtual void stopOK(JAISoundHandle &);
-    virtual void startSound(JAISoundID);
+    virtual JAISoundHandle *startSound(JAISoundID);
     virtual void startSoundIndex(JAISoundID, unsigned char);
-    virtual void startLevelSound(JAISoundID);
+    virtual JAISoundHandle *startLevelSound(JAISoundID);
     virtual void startLevelSoundIndex(JAISoundID, unsigned char);
 
     void stopSound(JAISoundID, unsigned long);

--- a/src/Game/AudioLib/AudRemixMgr.cpp
+++ b/src/Game/AudioLib/AudRemixMgr.cpp
@@ -1,0 +1,55 @@
+#include "Game/AudioLib/AudRemixMgr.hpp"
+#include "JSystem/JKernel/JKRHeap.hpp"
+
+AudRemixMgr::AudRemixMgr(JKRHeap *pHeap) {
+    mHeap = pHeap;
+    mGroups = nullptr;
+    mSoundObj = nullptr;
+    mRemixSeq = nullptr;
+}
+
+void AudRemixMgr::init() {
+    mSoundObj = new(mHeap, 0) AudSoundObject(nullptr, 0x10, mHeap);
+    mRemixSeq = new(mHeap, 0) AudRemixSequencer();
+}
+
+void AudRemixMgr::update() {
+    mRemixSeq->update();
+}
+
+void AudRemixMgr::setRemixSeqResource(void *ptr) {
+    u32 *newPtr = (u32 *)ptr;
+    int groupCount = *(newPtr);
+    newPtr++;
+    mGroupCount = groupCount;
+    newPtr += mGroupCount;
+    mGroups = new(mHeap, 0) RemixNoteGroupData[mGroupCount];
+    for (int i = 0; i < mGroupCount; i++)
+    {
+        RemixNoteGroupData *pGroupData = &mGroups[i];
+        pGroupData->mIndex = i;
+        pGroupData->mTrackCount = *newPtr++;
+        pGroupData->mNoteCount = *newPtr++;
+        pGroupData->_C = newPtr;
+        newPtr += pGroupData->mNoteCount;
+        pGroupData->mRemixTracks = new(mHeap, 0) RemixTrack[pGroupData->mTrackCount];
+        for (int j = 0; j < pGroupData->mTrackCount; j++)
+        {
+            pGroupData->mRemixTracks[j]._0 = *newPtr++;
+            pGroupData->mRemixTracks[j]._4 = newPtr;
+            newPtr += pGroupData->mNoteCount * 4;
+        }
+    }
+
+}
+
+RemixNoteGroupData *AudRemixMgr::getRemixNoteGroupDataFromMelodyNo(s32 melodyNo) const {
+    for (int i = 0; i < mGroupCount; i++)
+    {
+        if (melodyNo == mGroups[i].mIndex)
+        {
+            return &mGroups[i];
+        }
+    }
+    return nullptr;
+}

--- a/src/Game/AudioLib/AudRemixSequencer.cpp
+++ b/src/Game/AudioLib/AudRemixSequencer.cpp
@@ -1,0 +1,173 @@
+#include "Game/AudioLib/AudRemixSequencer.hpp"
+#include "Game/AudioLib/AudWrap.hpp"
+#include "Game/AudioLib/AudSoundNameConverter.hpp"
+#include "Game/AudioLib/AudSoundObject.hpp"
+#include "Game/GameAudio/AudTalkSoundData.hpp"
+#include "Game/SingletonHolder.hpp"
+#include "JSystem/JAudio2/JAISoundHandles.hpp"
+
+namespace
+{
+    static const char *cRemixNoteTrackSeId[] = {
+        "SE_RS_REMIX_NOTE_GET_TRK0",
+        "SE_RS_REMIX_NOTE_GET_TRK1",
+        "SE_RS_REMIX_NOTE_GET_TRK2",
+        "SE_RS_REMIX_NOTE_GET_TRK3",
+        "SE_RS_REMIX_NOTE_GET_TRK4",
+        "SE_RS_REMIX_NOTE_GET_TRK5",
+        "SE_RS_REMIX_NOTE_GET_TRK6",
+        "SE_RS_REMIX_NOTE_GET_TRK7",
+        "SE_RS_REMIX_NOTE_GET_TRK8",
+        "SE_RS_REMIX_NOTE_GET_TRK9",
+        "SE_RS_REMIX_NOTE_GET_TRK10",
+        "SE_RS_REMIX_NOTE_GET_TRK11",
+        "SE_RS_REMIX_NOTE_GET_TRK12",
+        "SE_RS_REMIX_NOTE_GET_TRK13",
+        "SE_RS_REMIX_NOTE_GET_TRK14",
+        "SE_RS_REMIX_NOTE_GET_TRK15",
+    };
+}
+
+AudRmxSeqNoteOnTimer::AudRmxSeqNoteOnTimer()
+{
+    _8 = nullptr;
+    _0 = 0.0f;
+    _4 = 0.0f;
+    _C = nullptr;
+    initData();
+}
+
+void AudRmxSeqNoteOnTimer::initData()
+{
+    _8 = nullptr;
+    _4 = 0.0f;
+    _0 = 0.0f;
+    _C = nullptr;
+}
+
+void AudRmxSeqNoteOnTimer::setData(const RemixNoteTrackData *trackData, const RemixNoteData *data) {
+    _C = trackData;
+    _8 = data;
+    _0 = data->_C;
+    _4 = _0 + data->_8;
+}
+
+bool AudRmxSeqNoteOnTimer::update(f32 f1)
+{
+    if (_4 <= 0.0f)
+    {
+        initData();
+        return false;
+    }
+
+    _4 -= f1;
+
+    if (_0 <= 0.0f)
+    {
+        if (_C != nullptr && _8 != nullptr)
+        {
+            AudRemixSequencer *pSeq = AudWrap::getRemixSequencer();
+            JAISoundID id = getFreeSeID();
+            JAISoundHandle *pHandle = AudWrap::getRemixSeqObject()->startSound(id);
+            AudWrap::getSystemSeObject()->writePort(pHandle, 0xc, _C->_0);
+            AudWrap::getSystemSeObject()->writePort(pHandle, 0xb, _8->_0);
+            AudWrap::getSystemSeObject()->writePort(pHandle, 0xf, _8->_4);
+
+            f32 x200 = pSeq->_200;
+            u16 length = (_8->_8 * 120.0f) / x200;
+            if (length < 1)
+            {
+                length = 1;
+            }
+            else if (length > 1440) {
+                length = 1440;
+            }
+            AudWrap::getSystemSeObject()->writePort(pHandle, 0xe, length);
+            _C = nullptr;
+            _8 = nullptr;
+        }
+        return true;
+    }
+    else {
+        _0 -= f1;
+        return false;
+    }
+}
+
+JAISoundID AudRmxSeqNoteOnTimer::getFreeSeID()
+{
+    
+    for (u32 i = 0; i < 0x10; i++)
+    {
+        JAISoundID id = AudSingletonHolder<AudSoundNameConverter>::sInstance->getSoundID(cRemixNoteTrackSeId[i]);
+        u32 *handleID = AudWrap::getRemixSeqObject()->getHandleSoundID(id);
+        if (handleID == nullptr)
+        {
+            return id;
+        }
+    }
+    JAISoundID id;
+    id.mID = -1;
+    return id;
+}
+
+AudRemixSequencer::AudRemixSequencer()
+{
+    _200 = 120.0f;
+    _204 = 0.0f;
+    initNoteOnBuff();
+    setTempo(120.0f);
+}
+
+void AudRemixSequencer::initNoteOnBuff()
+{
+    for (int i = 0; i < 0x20; i++)
+    {
+        _0[i].initData();
+    }
+}
+
+void AudRemixSequencer::update()
+{
+    for (int i = 0; i < 0x20; i++)
+    {
+        bool isUpdate = (_0[i]._4 > 0.0f);
+        if (isUpdate)
+        {
+            _0[i].update(_204);
+        }
+    }
+}
+
+void AudRemixSequencer::setTempo(f32 f1)
+{
+    _200 = f1;
+    f32 f2 = f1 + 0.0;
+    f32 f3 = 48.0f;
+    _204 = f3 * f2 / 3600.0f;
+}
+
+AudRmxSeqNoteOnTimer *AudRemixSequencer::newNoteOnTimer()
+{
+    for (int i = 0; i < 0x20; i++)
+    {
+        bool isUsed = (_0[i]._4 > 0.0f);
+        if (!isUsed)
+        {
+            return &_0[i];
+        }
+    }
+    return nullptr;
+}
+
+void AudRemixSequencer::addNoteData(const RemixNoteTrackData *trackData, const RemixNoteData *data)
+{
+    if (data->_0 >= 0)
+    {
+        AudRmxSeqNoteOnTimer *pTimer = newNoteOnTimer();
+        if (pTimer)
+        {
+            pTimer->setData(trackData, data);
+        }
+    }
+}


### PR DESCRIPTION
AudRemixMgr - all sections at 100%, I marked it as matching in configure.py
AudRemixSequencer - Extra .sbss section with `AudSingletonHolder<AudSoundNameConverter>::sInstance`, should go away when AudWrap is matched