### PR TITLE
JMapInfo complete

### DIFF
--- a/config/RMGK01/splits.txt
+++ b/config/RMGK01/splits.txt
@@ -8993,7 +8993,7 @@ Game/Util/BothDirList.cpp:
 
 Game/Util/CollisionPartsFilter.cpp:
 	.text       start:0x80401F44 end:0x80401F78
-	.data       start:0x805E6E30 end:0x805E6E98
+	.data       start:0x805E6E30 end:0x805E6E68
 
 Game/Util/DirectDraw.cpp:
 	.text       start:0x80401F78 end:0x804044C8
@@ -9021,10 +9021,11 @@ Game/Util/JMapIdInfo.cpp:
 
 Game/Util/JMapInfo.cpp:
 	.text       start:0x804060D0 end:0x80406564
+	.data       start:0x805E6E68 end:0x805E6E78
 
 Game/Util/JMapLinkInfo.cpp:
 	.text       start:0x80406564 end:0x8040679C
-	.data       start:0x805E6E98 end:0x805E6EE0
+	.data       start:0x805E6E78 end:0x805E6EE0
 
 Game/Util/JointController.cpp:
 	.text       start:0x8040679C end:0x80406A48

--- a/include/Game/Util/JMapInfo.hpp
+++ b/include/Game/Util/JMapInfo.hpp
@@ -40,7 +40,7 @@ inline bool compareValues<const char*>(const char* a, const char* b) {
     return strcmp(a, b) == 0;
 }
 
-inline const char* getEntryAddress(const JMapData *data, s32 dataOffset, int entryIndex) {
+inline const char* getEntryAddress(const JMapData* data, s32 dataOffset, int entryIndex) {
     return reinterpret_cast<const char*>(data) + dataOffset + entryIndex * data->mEntrySize;
 }
 
@@ -59,21 +59,21 @@ public:
         return mData == rhs.mData;
     }
 
-    bool attach(const void *);
-    void setName(const char *pName);
+    bool attach(const void*);
+    void setName(const char*);
     const char* getName() const;
-    s32 searchItemInfo(const char *pItem) const;
-    s32 getValueType(const char *) const;
-    bool getValueFast(int, int, const char **) const;
-    bool getValueFast(int, int, u32 *) const;
-    bool getValueFast(int, int, s32 *) const;
-    bool getValueFast(int entryIndex, int itemIndex, f32 *outValue) const {
+    s32 searchItemInfo(const char*) const;
+    s32 getValueType(const char*) const;
+    bool getValueFast(int, int, const char**) const;
+    bool getValueFast(int, int, u32*) const;
+    bool getValueFast(int, int, s32*) const;
+    bool getValueFast(int entryIndex, int itemIndex, f32* outValue) const {
         const JMapItem* item = &mData->mItems[itemIndex];
-        const char *valuePtr = getEntryAddress(mData, mData->mDataOffset, entryIndex) + item->mOffsData;
+        const char* valuePtr = getEntryAddress(mData, mData->mDataOffset, entryIndex) + item->mOffsData;
         *outValue = *reinterpret_cast<const f32*>(valuePtr);
         return true;
     }
-    JMapInfoIter findElementBinary(const char *, const char *) const;
+    JMapInfoIter findElementBinary(const char*, const char*) const;
 
     template<typename T>
     const bool getValue(int entryIndex, const char* key, T* outValue) const NO_INLINE {
@@ -85,7 +85,7 @@ public:
     }
 
     template<typename T>
-    JMapInfoIter findElement(const char *key, T searchValue, int startIndex) const NO_INLINE {
+    JMapInfoIter findElement(const char* key, T searchValue, int startIndex) const NO_INLINE {
         int entryIndex = startIndex;
         T value;
         while (entryIndex < (mData ? mData->mNumEntries : 0)) {
@@ -136,8 +136,8 @@ public:
     }
 
     template<typename T>
-    bool getValue(const char *key, T *outValue) const {
-        const JMapInfo *info = mInfo;
+    bool getValue(const char* key, T* outValue) const {
+        const JMapInfo* info = mInfo;
         s32 entryIndex = index;
         
         s32 itemIndex = info->searchItemInfo(key);
@@ -151,6 +151,6 @@ public:
     s32 index; // 0x4
 };
 
-JMapInfoIter JMapInfo::end() const {
-    return JMapInfoIter(this, mData ? mData->mNumEntries : 0);
+namespace MR {
+    JMapInfoIter findJMapInfoElementNoCase(const JMapInfo*, const char*, const char*, int);
 }

--- a/include/Game/Util/JMapInfo.hpp
+++ b/include/Game/Util/JMapInfo.hpp
@@ -51,14 +51,21 @@ public:
 
     template<typename T>
     JMapInfoIter findElement(const char *, s32, int) const;
-    JMapInfoIter end() const;
-
-    template<typename T>
-    const bool getValue(int, const char *, T *) const;
 
     bool getValueFast(int, int, const char **) const;
     bool getValueFast(int, int, u32 *) const;
     bool getValueFast(int, int, s32 *) const;
+
+    template<typename T>
+    const bool getValue(int entryIndex, const char* key, T* outValue) const NO_INLINE {
+        s32 itemIndex = searchItemInfo(key);
+        if (itemIndex < 0) {
+            return false;
+        }
+        return getValueFast(entryIndex, itemIndex, outValue);
+    }
+
+    JMapInfoIter end() const;
 
     const JMapData* mData; // 0x0
     const char* mName; // 0x4

--- a/include/Game/Util/JMapInfo.hpp
+++ b/include/Game/Util/JMapInfo.hpp
@@ -51,6 +51,10 @@ public:
         return *this;
     }
 
+    inline bool operator==(const JMapInfo &rhs) const {
+        return mData == rhs.mData;
+    }
+
     bool attach(const void *);
     void setName(const char *pName);
     const char* getName() const;
@@ -109,6 +113,10 @@ public:
         return *this;
     }
 
+    bool operator==(const JMapInfoIter &rhs) const NO_INLINE {
+        return index == rhs.index && mInfo && rhs.mInfo && *mInfo == *rhs.mInfo;
+    }
+
     template<typename T>
     bool getValue(const char *, T *) const;
 
@@ -138,8 +146,6 @@ public:
         return valid;
     }
 
-    bool operator==(const JMapInfoIter &) const;
-
     const JMapInfo* mInfo; // 0x0
-    s32 index;
+    s32 index; // 0x4
 };

--- a/include/Game/Util/JMapInfo.hpp
+++ b/include/Game/Util/JMapInfo.hpp
@@ -68,7 +68,7 @@ class JMapInfoIter {
 public:
     inline JMapInfoIter() { }
 
-    inline JMapInfoIter(JMapInfo* pInfo, s32 val) {
+    inline JMapInfoIter(const JMapInfo* pInfo, s32 val) {
         mInfo = pInfo;
         _4 = val;
     }
@@ -85,7 +85,7 @@ public:
     bool isValid() const NO_INLINE{
         bool valid = false;
         bool v3 = false;
-        JMapInfo* info = mInfo;
+        const JMapInfo* info = mInfo;
         if (info && _4 >= 0) {
             v3 = true;
         }
@@ -108,10 +108,8 @@ public:
         return valid;
     }
 
-    
-
     bool operator==(const JMapInfoIter &) const;
 
-    JMapInfo* mInfo; // 0x0
+    const JMapInfo* mInfo; // 0x0
     s32 _4;
 };

--- a/include/Game/Util/JMapInfo.hpp
+++ b/include/Game/Util/JMapInfo.hpp
@@ -98,14 +98,14 @@ class JMapInfoIter {
 public:
     inline JMapInfoIter() { }
 
-    inline JMapInfoIter(const JMapInfo* pInfo, s32 val) {
+    inline JMapInfoIter(const JMapInfo* pInfo, s32 idx) {
         mInfo = pInfo;
-        _4 = val;
+        index = idx;
     }
 
     inline JMapInfoIter& operator=(const JMapInfoIter &rIter) {
         mInfo = rIter.mInfo;
-        _4 = rIter._4;
+        index = rIter.index;
         return *this;
     }
 
@@ -116,12 +116,12 @@ public:
         bool valid = false;
         bool v3 = false;
         const JMapInfo* info = mInfo;
-        if (info && _4 >= 0) {
+        if (info && index >= 0) {
             v3 = true;
         }
 
         if (v3) {        
-            s32 pos = _4;
+            s32 pos = index;
             s32 num;
             if (info->mData) {
                 num = info->mData->mNumEntries;
@@ -141,5 +141,5 @@ public:
     bool operator==(const JMapInfoIter &) const;
 
     const JMapInfo* mInfo; // 0x0
-    s32 _4;
+    s32 index;
 };

--- a/include/Game/Util/JMapInfo.hpp
+++ b/include/Game/Util/JMapInfo.hpp
@@ -56,6 +56,8 @@ public:
     bool getValueFast(int, int, u32 *) const;
     bool getValueFast(int, int, s32 *) const;
 
+    JMapInfoIter findElementBinary(const char *, const char *) const;
+
     template<typename T>
     const bool getValue(int entryIndex, const char* key, T* outValue) const NO_INLINE {
         s32 itemIndex = searchItemInfo(key);

--- a/include/Game/Util/JMapInfo.hpp
+++ b/include/Game/Util/JMapInfo.hpp
@@ -26,7 +26,7 @@ struct JMapData {
     s32 mNumFields;     // 0x4
     s32 mDataOffset;    // 0x8
     u32 mEntrySize;     // 0xC
-    const JMapItem mItems;   // 0x10
+    const JMapItem mItems[];   // 0x10
 };
 
 class JMapInfo {

--- a/include/Game/Util/JMapUtil.hpp
+++ b/include/Game/Util/JMapUtil.hpp
@@ -110,7 +110,7 @@ namespace MR {
         ret = false;
         flag = false;
 
-        if (rIter.mInfo != nullptr && rIter.index >= 0) {
+        if (rIter.mInfo != nullptr && rIter.mIndex >= 0) {
             flag = true;
         }
 
@@ -123,7 +123,7 @@ namespace MR {
                 numEntries = 0;
             }
 
-            if (rIter.index < numEntries) {
+            if (rIter.mIndex < numEntries) {
                 ret = true;
             }
         }

--- a/include/Game/Util/JMapUtil.hpp
+++ b/include/Game/Util/JMapUtil.hpp
@@ -110,7 +110,7 @@ namespace MR {
         ret = false;
         flag = false;
 
-        if (rIter.mInfo != nullptr && rIter._4 >= 0) {
+        if (rIter.mInfo != nullptr && rIter.index >= 0) {
             flag = true;
         }
 
@@ -123,7 +123,7 @@ namespace MR {
                 numEntries = 0;
             }
 
-            if (rIter._4 < numEntries) {
+            if (rIter.index < numEntries) {
                 ret = true;
             }
         }

--- a/src/Game/AreaObj/AreaObjContainer.cpp
+++ b/src/Game/AreaObj/AreaObjContainer.cpp
@@ -13,7 +13,7 @@ void AreaObjContainer::init(const JMapInfoIter &rIter) {
         AreaObjMgr* mgr = entry->mFuncPtr(entry->_4, entry->mName);
         JMapInfoIter iter;
         iter.mInfo = nullptr;
-        iter._4 = -1;
+        iter.mIndex = -1;
         mgr->init(iter);
         s32 num = mNumManagers;
         mNumManagers++;

--- a/src/Game/AreaObj/CubeCamera.cpp
+++ b/src/Game/AreaObj/CubeCamera.cpp
@@ -21,7 +21,7 @@ void CubeCameraArea::init(const JMapInfoIter &rIter) {
     const char* valid;
 
     if (inf >= 0) {
-        retVal = info->getValueFast(rIter.index, inf, &valid);
+        retVal = info->getValueFast(rIter.mIndex, inf, &valid);
     }
     else {
         retVal = false;
@@ -41,7 +41,7 @@ void CubeCameraArea::init(const JMapInfoIter &rIter) {
     bool r3 = false;
 
     if (rIter.mInfo) {
-        if (rIter.index >= 0) {
+        if (rIter.mIndex >= 0) {
             r3 = true;
         }
     }

--- a/src/Game/AreaObj/CubeCamera.cpp
+++ b/src/Game/AreaObj/CubeCamera.cpp
@@ -21,7 +21,7 @@ void CubeCameraArea::init(const JMapInfoIter &rIter) {
     const char* valid;
 
     if (inf >= 0) {
-        retVal = info->getValueFast(rIter._4, inf, &valid);
+        retVal = info->getValueFast(rIter.index, inf, &valid);
     }
     else {
         retVal = false;
@@ -41,7 +41,7 @@ void CubeCameraArea::init(const JMapInfoIter &rIter) {
     bool r3 = false;
 
     if (rIter.mInfo) {
-        if (rIter._4 >= 0) {
+        if (rIter.index >= 0) {
             r3 = true;
         }
     }

--- a/src/Game/Boss/SkeletalFishBossInfo.cpp
+++ b/src/Game/Boss/SkeletalFishBossInfo.cpp
@@ -32,8 +32,8 @@ void SkeletalFishBossInfo::init(const JMapInfoIter &rIter) {
         volatile JMapInfoIter level_iter;
         level_iter.mInfo = (JMapInfo*)info;
         what.mInfo = (JMapInfo*)info;
-        level_iter._4 = 0;
-        what._4 = 0;
+        level_iter.mIndex = 0;
+        what.mIndex = 0;
         loadLevelStatus(what);
     }
 }

--- a/src/Game/Camera/DotCamParams.cpp
+++ b/src/Game/Camera/DotCamParams.cpp
@@ -9,7 +9,7 @@ DotCamReader::~DotCamReader() {
 DotCamReaderInBin::DotCamReaderInBin(const void *pData) :
     mVersion(0), _8(nullptr), mMapInfo() {
     mMapIter.mInfo = nullptr;
-    mMapIter._4 = -1;
+    mMapIter.mIndex = -1;
     init(pData);
 }
 
@@ -36,7 +36,7 @@ bool DotCamReaderInBin::hasMoreChunk() const {
 
         const JMapInfo &mapInfo = mMapInfo;
 
-        if (mMapIter._4 == iVar2 && mMapIter.mInfo != nullptr && mapInfo.mData != nullptr) {
+        if (mMapIter.mIndex == iVar2 && mMapIter.mInfo != nullptr && mapInfo.mData != nullptr) {
             if (mMapIter.mInfo->mData == mapInfo.mData) {
                 bVar1 = true;
             }
@@ -53,7 +53,7 @@ bool DotCamReaderInBin::hasMoreChunk() const {
 
 void DotCamReaderInBin::nextToChunk() {
     if (mMapIter.isValid()) {
-        mMapIter._4++;
+        mMapIter.mIndex++;
     }
 }
 
@@ -92,8 +92,8 @@ bool DotCamReaderInBin::getValueVec(const char *pName, TVec3f *pOut) {
 }
 
 bool DotCamReaderInBin::getValueString(const char *pName, const char **pOut) {
-    s32 iVar3 = mMapIter._4;
-    JMapInfo *info = mMapIter.mInfo;
+    s32 iVar3 = mMapIter.mIndex;
+    const JMapInfo *info = mMapIter.mInfo;
     s32 index = info->searchItemInfo(pName);
 
     if (index < 0) {
@@ -116,6 +116,6 @@ void DotCamReaderInBin::init(const void *pData) {
     }
 
     mMapIter.mInfo = &mMapInfo;
-    mMapIter._4 = 0;
+    mMapIter.mIndex = 0;
 }
 #endif

--- a/src/Game/LiveActor/RailRider.cpp
+++ b/src/Game/LiveActor/RailRider.cpp
@@ -20,7 +20,7 @@ RailRider::RailRider(const JMapInfoIter &rIter) {
     const JMapInfo* info = nullptr;
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.mIndex = -1;
     MR::getRailInfo(&iter, &info, rIter);
     initBezierRail(iter, info);
 }
@@ -45,7 +45,7 @@ RailRider::RailRider(s32 a1, s32 a2) {
     const JMapInfo* info = nullptr;
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.mIndex = -1;
     MR::getCameraRailInfo(&iter, &info, a1, a2);
     initBezierRail(iter, info);
 }
@@ -210,7 +210,7 @@ s32 RailRider::getPointNum() const {
 void RailRider::copyPointPos(TVec3f *pOut, s32 pointNum) const {
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.mIndex = -1;
     mBezierRail->calcRailCtrlPointIter(&iter, pointNum);
     MR::getRailPointPos0(iter, pOut);
 }
@@ -234,7 +234,7 @@ bool RailRider::getPointArgS32NoInit(const char *pStr, s32 *pOut, s32 pointNum) 
     s32 val;
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.mIndex = -1;
 
     mBezierRail->calcRailCtrlPointIter(&iter, pointNum);
     val = -1;
@@ -251,7 +251,7 @@ bool RailRider::getPointArgS32NoInit(const char *pStr, s32 *pOut, s32 pointNum) 
 bool RailRider::getPointArgS32WithInit(const char *pStr, s32 *pOut, s32 pointNum) const {
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.mIndex = -1;
     mBezierRail->calcRailCtrlPointIter(&iter, pointNum);
     iter.getValue<s32>(pStr, pOut);
     return true;
@@ -261,7 +261,7 @@ bool RailRider::getCurrentPointArgS32NoInit(const char *pStr, s32 *pOut) const {
     s32 val;
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.mIndex = -1;
 
     mBezierRail->calcRailCtrlPointIter(&iter, mCurPoint);
     val = -1;
@@ -278,7 +278,7 @@ bool RailRider::getCurrentPointArgS32NoInit(const char *pStr, s32 *pOut) const {
 bool RailRider::getCurrentPointArgS32WithInit(const char *pStr, s32 *pOut) const {
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.mIndex = -1;
     mBezierRail->calcRailCtrlPointIter(&iter, mCurPoint);
     iter.getValue<s32>(pStr, pOut);
     return true;
@@ -288,7 +288,7 @@ bool RailRider::getNextPointArgS32NoInit(const char *pStr, s32 *pOut) const {
     s32 val;
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.mIndex = -1;
 
     mBezierRail->calcRailCtrlPointIter(&iter, getNextPointNo());
     val = -1;
@@ -305,7 +305,7 @@ bool RailRider::getNextPointArgS32NoInit(const char *pStr, s32 *pOut) const {
 bool RailRider::getNextPointArgS32WithInit(const char *pStr, s32 *pOut) const {
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.mIndex = -1;
     mBezierRail->calcRailCtrlPointIter(&iter, getNextPointNo());
     iter.getValue<s32>(pStr, pOut);
     return true;
@@ -336,7 +336,7 @@ void RailRider::syncPosDir() {
 
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.mIndex = -1;
     mBezierRail->calcCurrentRailCtrlPointIter(&iter, mCoord, mIsNotReverse);
     iter.getValue<s32>("id", &mCurPoint);
 }

--- a/src/Game/Map/BezierRail.cpp
+++ b/src/Game/Map/BezierRail.cpp
@@ -195,7 +195,7 @@ void BezierRail::calcCurrentRailCtrlPointIter(JMapInfoIter *pIter, f32 a2, bool 
 }
 
 void BezierRail::calcRailCtrlPointIter(JMapInfoIter *pIter, int idx) const {
-    pIter->_4 = idx;
+    pIter->mIndex = idx;
     pIter->mInfo = _18;
 }
 

--- a/src/Game/Map/HitInfo.cpp
+++ b/src/Game/Map/HitInfo.cpp
@@ -184,7 +184,7 @@ JMapInfoIter Triangle::getAttributes() const {
     if (mIdx == 0xFFFFFFFF) {
         JMapInfoIter iter;
         iter.mInfo = nullptr;
-        iter._4 = -1;
+        iter.mIndex = -1;
 
         return iter;
     }

--- a/src/Game/Map/KCollision.cpp
+++ b/src/Game/Map/KCollision.cpp
@@ -163,7 +163,7 @@ JMapInfoIter KCollisionServer::getAttributes(u32 index) const {
 
     JMapInfoIter iter;
     iter.mInfo = mapInfo;
-    iter._4 = prism->mAttribute;
+    iter.mIndex = prism->mAttribute;
 
     return iter;
 }

--- a/src/Game/NameObj/NameObj.cpp
+++ b/src/Game/NameObj/NameObj.cpp
@@ -41,7 +41,7 @@ void NameObj::calcViewAndEntry() {
 void NameObj::initWithoutIter() {
     JMapInfoIter iter;
     iter.mInfo = 0;
-    iter._4 = -1;
+    iter.mIndex = -1;
     init(iter);
 }
 

--- a/src/Game/Scene/SceneDataInitializer.cpp
+++ b/src/Game/Scene/SceneDataInitializer.cpp
@@ -21,7 +21,7 @@ void SceneDataInitializer::startStageFileLoadAfterScenarioSelected() {
     NameObjArchiveListCollector collector;
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.mIndex = -1;
 
     LuigiLetter::makeArchiveListForMenu(&collector, iter);
 

--- a/src/Game/Scene/StageDataHolder.cpp
+++ b/src/Game/Scene/StageDataHolder.cpp
@@ -148,7 +148,7 @@ void StageDataHolder::initPlacement() {
 JMapInfo StageDataHolder::getCommonPathPointInfo(const JMapInfo **ppOut, int idx) const {
     const JMapInfo* pInfo = findJmpInfoFromArray(&mPathObjs, "CommonPathInfo");
     JMapInfoIter pathIter = pInfo->findElement<s32>("l_id", idx, 0);
-    return getCommonPathPointInfoFromRailDataIndex(ppOut, pathIter._4);
+    return getCommonPathPointInfoFromRailDataIndex(ppOut, pathIter.index);
 }
 
 JMapInfo StageDataHolder::getCommonPathPointInfoFromRailDataIndex(const JMapInfo **ppInfo, int idx) const {
@@ -162,7 +162,7 @@ JMapInfo StageDataHolder::getCommonPathPointInfoFromRailDataIndex(const JMapInfo
 s32 StageDataHolder::getCurrentStartCameraId() const {
     JMapInfoIter marioIter = makeCurrentMarioJMapInfoIter();
     s32 cameraID;
-    bool ret = marioIter.mInfo->getValue<s32>(marioIter._4, "Camera_id", &cameraID);
+    bool ret = marioIter.mInfo->getValue<s32>(marioIter.index, "Camera_id", &cameraID);
 
     if (ret) {
         return cameraID;
@@ -176,12 +176,12 @@ void StageDataHolder::getStartCameraIdInfoFromStartDataIndex(JMapIdInfo *pInfo, 
     JMapInfoIter startIter = getStartJMapInfoIterFromStartDataIndex(startDataIdx);
     copy = startIter;
     s32 cameraID;
-    copy.mInfo->getValue<s32>(startIter._4, "Camera_id", &cameraID);
+    copy.mInfo->getValue<s32>(startIter.index, "Camera_id", &cameraID);
     pInfo->initalize(cameraID, copy);
 }
 
 const StageDataHolder* StageDataHolder::findPlacedStageDataHolder(const JMapInfoIter &rIter) const {
-    s32 data = (s32)rIter.mInfo->mData + rIter.mInfo->mData->mDataOffset + rIter.mInfo->mData->mEntrySize * rIter._4;
+    s32 data = (s32)rIter.mInfo->mData + rIter.mInfo->mData->mDataOffset + rIter.mInfo->mData->mEntrySize * rIter.index;
 
     if (_E4 <= data && data < _E8) {
         return this;
@@ -241,7 +241,7 @@ const char* StageDataHolder::getJapaneseObjectName(const char *pName) const {
     }
 
     const char* japaneseName;
-    englishName.mInfo->getValue<const char *>(englishName._4, "jp_name", &japaneseName);
+    englishName.mInfo->getValue<const char *>(englishName.index, "jp_name", &japaneseName);
     return japaneseName;
 }
 
@@ -325,7 +325,7 @@ JMapInfoIter StageDataHolder::getStartJMapInfoIterFromStartDataIndex(int idx_) c
         if (idx < curIdx) {
             JMapInfoIter iter;
             iter.mInfo = pInfo;
-            iter._4 = idx;
+            iter.index = idx;
 
             return iter;
         }
@@ -348,7 +348,7 @@ JMapInfoIter StageDataHolder::getStartJMapInfoIterFromStartDataIndex(int idx_) c
 
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter._4 = -1;
+    iter.index = -1;
 
     return iter;
 }

--- a/src/Game/Scene/StageDataHolder.cpp
+++ b/src/Game/Scene/StageDataHolder.cpp
@@ -6,6 +6,10 @@
 #include "JSystem/JKernel/JKRArchive.hpp"
 #include <cstdio>
 
+JMapInfoIter JMapInfo::end() const {
+    return JMapInfoIter(this, mData ? mData->mNumEntries : 0);
+}
+
 namespace {
     static bool isPrioPlacementObjInfo(const char *pName) NO_INLINE {
         return MR::isEqualStringCase(pName, "AreaObjInfo") 

--- a/src/Game/Scene/StageDataHolder.cpp
+++ b/src/Game/Scene/StageDataHolder.cpp
@@ -152,7 +152,7 @@ void StageDataHolder::initPlacement() {
 JMapInfo StageDataHolder::getCommonPathPointInfo(const JMapInfo **ppOut, int idx) const {
     const JMapInfo* pInfo = findJmpInfoFromArray(&mPathObjs, "CommonPathInfo");
     JMapInfoIter pathIter = pInfo->findElement<s32>("l_id", idx, 0);
-    return getCommonPathPointInfoFromRailDataIndex(ppOut, pathIter.index);
+    return getCommonPathPointInfoFromRailDataIndex(ppOut, pathIter.mIndex);
 }
 
 JMapInfo StageDataHolder::getCommonPathPointInfoFromRailDataIndex(const JMapInfo **ppInfo, int idx) const {
@@ -166,7 +166,7 @@ JMapInfo StageDataHolder::getCommonPathPointInfoFromRailDataIndex(const JMapInfo
 s32 StageDataHolder::getCurrentStartCameraId() const {
     JMapInfoIter marioIter = makeCurrentMarioJMapInfoIter();
     s32 cameraID;
-    bool ret = marioIter.mInfo->getValue<s32>(marioIter.index, "Camera_id", &cameraID);
+    bool ret = marioIter.mInfo->getValue<s32>(marioIter.mIndex, "Camera_id", &cameraID);
 
     if (ret) {
         return cameraID;
@@ -180,12 +180,12 @@ void StageDataHolder::getStartCameraIdInfoFromStartDataIndex(JMapIdInfo *pInfo, 
     JMapInfoIter startIter = getStartJMapInfoIterFromStartDataIndex(startDataIdx);
     copy = startIter;
     s32 cameraID;
-    copy.mInfo->getValue<s32>(startIter.index, "Camera_id", &cameraID);
+    copy.mInfo->getValue<s32>(startIter.mIndex, "Camera_id", &cameraID);
     pInfo->initalize(cameraID, copy);
 }
 
 const StageDataHolder* StageDataHolder::findPlacedStageDataHolder(const JMapInfoIter &rIter) const {
-    s32 data = (s32)rIter.mInfo->mData + rIter.mInfo->mData->mDataOffset + rIter.mInfo->mData->mEntrySize * rIter.index;
+    s32 data = (s32)rIter.mInfo->mData + rIter.mInfo->mData->mDataOffset + rIter.mInfo->mData->mEntrySize * rIter.mIndex;
 
     if (_E4 <= data && data < _E8) {
         return this;
@@ -245,7 +245,7 @@ const char* StageDataHolder::getJapaneseObjectName(const char *pName) const {
     }
 
     const char* japaneseName;
-    englishName.mInfo->getValue<const char *>(englishName.index, "jp_name", &japaneseName);
+    englishName.mInfo->getValue<const char *>(englishName.mIndex, "jp_name", &japaneseName);
     return japaneseName;
 }
 
@@ -329,7 +329,7 @@ JMapInfoIter StageDataHolder::getStartJMapInfoIterFromStartDataIndex(int idx_) c
         if (idx < curIdx) {
             JMapInfoIter iter;
             iter.mInfo = pInfo;
-            iter.index = idx;
+            iter.mIndex = idx;
 
             return iter;
         }
@@ -352,7 +352,7 @@ JMapInfoIter StageDataHolder::getStartJMapInfoIterFromStartDataIndex(int idx_) c
 
     JMapInfoIter iter;
     iter.mInfo = nullptr;
-    iter.index = -1;
+    iter.mIndex = -1;
 
     return iter;
 }

--- a/src/Game/Util/GravityUtil.cpp
+++ b/src/Game/Util/GravityUtil.cpp
@@ -12,7 +12,7 @@ namespace {
 
 	void getJMapInfoArgPlus(const JMapInfoIter &rIter, const char *pFieldName, s32 *pDest) {
 		// Get row and column of data
-		s32 row = rIter.index;
+		s32 row = rIter.mIndex;
 		JMapInfo* pInfo = rIter.mInfo;
 		s32 column = pInfo->searchItemInfo(pFieldName);
 

--- a/src/Game/Util/GravityUtil.cpp
+++ b/src/Game/Util/GravityUtil.cpp
@@ -13,7 +13,7 @@ namespace {
 	void getJMapInfoArgPlus(const JMapInfoIter &rIter, const char *pFieldName, s32 *pDest) {
 		// Get row and column of data
 		s32 row = rIter.mIndex;
-		JMapInfo* pInfo = rIter.mInfo;
+		const JMapInfo* pInfo = rIter.mInfo;
 		s32 column = pInfo->searchItemInfo(pFieldName);
 
 		// Try to read value

--- a/src/Game/Util/GravityUtil.cpp
+++ b/src/Game/Util/GravityUtil.cpp
@@ -12,7 +12,7 @@ namespace {
 
 	void getJMapInfoArgPlus(const JMapInfoIter &rIter, const char *pFieldName, s32 *pDest) {
 		// Get row and column of data
-		s32 row = rIter._4;
+		s32 row = rIter.index;
 		JMapInfo* pInfo = rIter.mInfo;
 		s32 column = pInfo->searchItemInfo(pFieldName);
 

--- a/src/Game/Util/JMapInfo.cpp
+++ b/src/Game/Util/JMapInfo.cpp
@@ -14,10 +14,8 @@ bool JMapInfo::attach(const void *pData) {
     if (pData == nullptr) {
         return false;
     }
-    else {
-        mData = static_cast<const JMapData*>(pData);
-        return true;
-    }
+    mData = static_cast<const JMapData*>(pData);
+    return true;
 }
 
 void JMapInfo::setName(const char *pName) {
@@ -28,7 +26,22 @@ const char* JMapInfo::getName() const {
     return mName;
 }
 
-// s32 JMapInfo::searchItemInfo(const char *pItem) const
+s32 JMapInfo::searchItemInfo(const char *key) const {
+    if (!mData) {
+        return -1;
+    }
+
+    s32 nFields = mData ? mData->mNumFields : 0;
+    u32 hash = JGadget::getHashCode(key);
+
+    for (int i = 0; i < nFields; ++i) {
+        if ((&mData->mItems + i)->mHash == hash) {
+            return i;
+        }
+    }
+    
+    return -1;
+}
 
 s32 JMapInfo::getValueType(const char *pItem) const {
     s32 itemId = searchItemInfo(pItem);

--- a/src/Game/Util/JMapInfo.cpp
+++ b/src/Game/Util/JMapInfo.cpp
@@ -10,7 +10,7 @@ JMapInfo::~JMapInfo() {
 
 }
 
-bool JMapInfo::attach(const void *pData) {
+bool JMapInfo::attach(const void* pData) {
     if (pData == nullptr) {
         return false;
     }
@@ -18,7 +18,7 @@ bool JMapInfo::attach(const void *pData) {
     return true;
 }
 
-void JMapInfo::setName(const char *pName) {
+void JMapInfo::setName(const char* pName) {
     mName = pName;
 }
 
@@ -26,7 +26,7 @@ const char* JMapInfo::getName() const {
     return mName;
 }
 
-s32 JMapInfo::searchItemInfo(const char *key) const {
+s32 JMapInfo::searchItemInfo(const char* key) const {
     if (!dataExists()) {
         return -1;
     }
@@ -43,7 +43,7 @@ s32 JMapInfo::searchItemInfo(const char *key) const {
     return -1;
 }
 
-s32 JMapInfo::getValueType(const char *pItem) const {
+s32 JMapInfo::getValueType(const char* pItem) const {
     s32 itemId = searchItemInfo(pItem);
 
     if (itemId < 0) {
@@ -52,14 +52,14 @@ s32 JMapInfo::getValueType(const char *pItem) const {
     return mData->mItems[itemId].mType;
 }
 
-bool JMapInfo::getValueFast(int entryIndex, int itemIndex, const char **outValue) const {
-    const JMapItem *item = &mData->mItems[itemIndex];
-    const char *valuePtr = getEntryAddress(mData, mData->mDataOffset, entryIndex) + item->mOffsData;
+bool JMapInfo::getValueFast(int entryIndex, int itemIndex, const char** outValue) const {
+    const JMapItem* item = &mData->mItems[itemIndex];
+    const char* valuePtr = getEntryAddress(mData, mData->mDataOffset, entryIndex) + item->mOffsData;
 
     switch (item->mType) {
         case JMAP_VALUE_TYPE_STRING_PTR:
             s32 nEntries = mData ? mData->mNumEntries : 0;
-            const char *stringTableOffset = getEntryAddress(mData, mData->mDataOffset, nEntries);
+            const char* stringTableOffset = getEntryAddress(mData, mData->mDataOffset, nEntries);
             *outValue = stringTableOffset + *reinterpret_cast<const u32*>(valuePtr);
             break;
         default:
@@ -70,9 +70,9 @@ bool JMapInfo::getValueFast(int entryIndex, int itemIndex, const char **outValue
     return true;
 }
 
-bool JMapInfo::getValueFast(int entryIndex, int itemIndex, u32 *outValue) const {
-    const JMapItem *item = &mData->mItems[itemIndex];
-    const char *valuePtr = getEntryAddress(mData, mData->mDataOffset, entryIndex) + item->mOffsData;
+bool JMapInfo::getValueFast(int entryIndex, int itemIndex, u32* outValue) const {
+    const JMapItem* item = &mData->mItems[itemIndex];
+    const char* valuePtr = getEntryAddress(mData, mData->mDataOffset, entryIndex) + item->mOffsData;
 
     u32 rawValue;
     switch (item->mType) {
@@ -94,12 +94,12 @@ bool JMapInfo::getValueFast(int entryIndex, int itemIndex, u32 *outValue) const 
     return true;
 }
 
-bool JMapInfo::getValueFast(int entryIndex, int itemIndex, s32 *outValue) const {
+bool JMapInfo::getValueFast(int entryIndex, int itemIndex, s32* outValue) const {
     const JMapItem* item = &mData->mItems[itemIndex];
     if (item->mShift != 0) {
         goto FAIL;
     }
-    const char *valuePtr = getEntryAddress(mData, mData->mDataOffset, entryIndex) + item->mOffsData;
+    const char* valuePtr = getEntryAddress(mData, mData->mDataOffset, entryIndex) + item->mOffsData;
     
     switch (item->mType) {
         case JMAP_VALUE_TYPE_LONG:
@@ -128,14 +128,14 @@ FAIL:
     return false;
 }
 
-JMapInfoIter JMapInfo::findElementBinary(const char *key, const char *value) const {
+JMapInfoIter JMapInfo::findElementBinary(const char* key, const char* value) const {
     int low = 0;
     int high = mData ? mData->mNumEntries : 0;
 
-    const char *nextVal;
+    const char* nextVal;
     while (low < high) {
         int mid = (low + high) / 2;
-        getValue<const char *>(mid, key, &nextVal);
+        getValue<const char*>(mid, key, &nextVal);
         int comparison = strcmp(nextVal, value);
         if (comparison == 0) {
             return JMapInfoIter(this, mid);

--- a/src/Game/Util/JMapInfo.cpp
+++ b/src/Game/Util/JMapInfo.cpp
@@ -1,5 +1,6 @@
 #include "Game/Util/JMapInfo.hpp"
 #include "JSystem/JGadget/hashcode.hpp"
+#include <cstring>
 
 JMapInfo::JMapInfo() {
     mData = nullptr;
@@ -35,7 +36,7 @@ s32 JMapInfo::searchItemInfo(const char *key) const {
     u32 hash = JGadget::getHashCode(key);
 
     for (int i = 0; i < nFields; ++i) {
-        if ((&mData->mItems + i)->mHash == hash) {
+        if ((&mData->mItems)[i].mHash == hash) {
             return i;
         }
     }
@@ -49,7 +50,27 @@ s32 JMapInfo::getValueType(const char *pItem) const {
     if (itemId < 0) {
         return JMAP_VALUE_TYPE_NULL;
     }
-    else {
-        return static_cast<const JMapItem*>(&mData->mItems)[itemId].mType;
+    return (&mData->mItems)[itemId].mType;
+}
+
+JMapInfoIter JMapInfo::findElementBinary(const char *key, const char *value) const {
+    int low = 0;
+    int high = mData ? mData->mNumEntries : 0;
+
+    const char *nextVal;
+    while (low < high) {
+        int mid = (low + high) / 2;
+        getValue<const char *>(mid, key, &nextVal);
+        int comparison = strcmp(nextVal, value);
+        if (comparison == 0) {
+            return JMapInfoIter(this, mid);
+        }
+        else if (comparison < 0) {
+            low = mid + 1;
+        }
+        else {
+            high = mid;
+        }
     }
+    return end();
 }

--- a/src/Game/Util/JMapInfo.cpp
+++ b/src/Game/Util/JMapInfo.cpp
@@ -52,10 +52,6 @@ s32 JMapInfo::getValueType(const char *pItem) const {
     return mData->mItems[itemId].mType;
 }
 
-inline const char* getEntryAddress(const JMapData *data, s32 dataOffset, int entryIndex) {
-    return reinterpret_cast<const char*>(data) + dataOffset + entryIndex * data->mEntrySize;
-}
-
 bool JMapInfo::getValueFast(int entryIndex, int itemIndex, const char **outValue) const {
     const JMapItem *item = &mData->mItems[itemIndex];
     const char *valuePtr = getEntryAddress(mData, mData->mDataOffset, entryIndex) + item->mOffsData;

--- a/src/Game/Util/JMapInfo.cpp
+++ b/src/Game/Util/JMapInfo.cpp
@@ -128,7 +128,7 @@ FAIL:
     return false;
 }
 
-JMapInfoIter MR::findJMapInfoElementNoCase(const JMapInfo* pInfo, const char *key, const char *searchValue, int startIndex) {
+JMapInfoIter MR::findJMapInfoElementNoCase(const JMapInfo* pInfo, const char* key, const char* searchValue, int startIndex) {
     int entryIndex = startIndex;
     const char* value;
     while (entryIndex < pInfo->getNumEntries()) {

--- a/src/Game/Util/JMapInfo.cpp
+++ b/src/Game/Util/JMapInfo.cpp
@@ -1,4 +1,5 @@
 #include "Game/Util/JMapInfo.hpp"
+#include "Game/Util/StringUtil.hpp"
 #include "JSystem/JGadget/hashcode.hpp"
 
 JMapInfo::JMapInfo() {
@@ -126,6 +127,19 @@ bool JMapInfo::getValueFast(int entryIndex, int itemIndex, s32* outValue) const 
     return true;
 FAIL:
     return false;
+}
+
+JMapInfoIter MR::findJMapInfoElementNoCase(const JMapInfo* pInfo, const char *key, const char *searchValue, int startIndex) {
+    int entryIndex = startIndex;
+    const char* value;
+    while (entryIndex < (pInfo->mData ? pInfo->mData->mNumEntries : 0)) {
+        pInfo->getValue<const char*>(entryIndex, key, &value);
+        if (MR::isEqualStringCase(value, searchValue)) {
+            return JMapInfoIter(pInfo, entryIndex);
+        }
+        entryIndex++;
+    }
+    return pInfo->end();
 }
 
 JMapInfoIter JMapInfo::findElementBinary(const char* key, const char* value) const {

--- a/src/Game/Util/JMapInfo.cpp
+++ b/src/Game/Util/JMapInfo.cpp
@@ -1,6 +1,5 @@
 #include "Game/Util/JMapInfo.hpp"
 #include "JSystem/JGadget/hashcode.hpp"
-#include <cstring>
 
 JMapInfo::JMapInfo() {
     mData = nullptr;
@@ -28,11 +27,11 @@ const char* JMapInfo::getName() const {
 }
 
 s32 JMapInfo::searchItemInfo(const char *key) const {
-    if (!mData) {
+    if (!dataExists()) {
         return -1;
     }
 
-    s32 nFields = mData ? mData->mNumFields : 0;
+    s32 nFields = dataExists() ? mData->mNumFields : 0;
     u32 hash = JGadget::getHashCode(key);
 
     for (int i = 0; i < nFields; ++i) {


### PR DESCRIPTION
Full match of JMapInfo.cpp

I put JMapInfo::end in StageDataHolder.cpp (the split it's currently part of) because I was having trouble with a circular dependency between it and JMapInfoIter::isValid that I was unable to find another way to resolve. If there is a different preferred solution, please let me know.

Also, I am still getting comfortable with inline, so I recognize some of my inline functions probably could be improved. In particular with the various getValueFast methods, I know there's some inlining going on, and I played with it for multiple hours but never got anything better than what I'm submitting.