### PR TITLE
Migrate `PSVECSquareXXX` calls to `TVec3` calls

### DIFF
--- a/src/Game/Boss/TripodBossLeg.cpp
+++ b/src/Game/Boss/TripodBossLeg.cpp
@@ -360,7 +360,7 @@ void TripodBossLeg::exeMoveToLandingPos() {
     updatePose();
     updateAnkleSlerpToBasePose();
 
-    if (JMathInlineVEC::PSVECSquareDistance(&mForceEndPoint, &_240) < 90000.0f) {
+    if (mForceEndPoint.squared(_240) < 90000.0f) {
         setNerve(&NrvTripodBossLeg::TripodBossLegNrvStampSign::sInstance);
     }
 }

--- a/src/Game/Enemy/BasaBasa.cpp
+++ b/src/Game/Enemy/BasaBasa.cpp
@@ -758,7 +758,7 @@ void BasaBasa::controlVelocity() {
 
         if (PSVECMag(&mVelocity) > v6) {
             TVec3f* velocityPtr = &mVelocity;
-            f32 sqr = JMathInlineVEC::PSVECSquareMag(velocityPtr);
+            f32 sqr = velocityPtr->squared();
             if (sqr <= 0.0000038146973f) {
                 velocityPtr->scale(v6 * JGeometry::TUtil< f32 >::inv_sqrt(sqr));
             }

--- a/src/Game/Enemy/IceMerameraKing.cpp
+++ b/src/Game/Enemy/IceMerameraKing.cpp
@@ -720,7 +720,7 @@ void IceMerameraKing::addVelocityToInitPos() {
     if (0.0f < mGravity.dot(v12)) {
         MR::vecKillElement(v12, mGravity, &v12);
     }
-    f32 squared = JMathInlineVEC::PSVECSquareMag(&v12);
+    f32 squared = v12.squared();
     f32 half = 0.5f;
 
     if (squared <= 0.0000038146973f) {

--- a/src/Game/Gravity/WireGravity.cpp
+++ b/src/Game/Gravity/WireGravity.cpp
@@ -23,7 +23,7 @@ bool WireGravity::calcOwnGravityVector(TVec3f* pDest, f32* pScalar, const TVec3f
         TVec3f positionProjectedOntoWire;
         MR::calcPerpendicFootToLineInside(&positionProjectedOntoWire, rPos, mPoints[i], mPoints[i + 1]);
 
-        f32 squareDistance = JMathInlineVEC::PSVECSquareDistance(&rPos, &positionProjectedOntoWire);
+        f32 squareDistance = rPos.squared(positionProjectedOntoWire);
         if (squareDistance < distance || distance < 0.0f) {
             pointOfAttraction = positionProjectedOntoWire;
             distance = squareDistance;

--- a/src/Game/Map/BezierRail.cpp
+++ b/src/Game/Map/BezierRail.cpp
@@ -194,7 +194,7 @@ f32 BezierRailPart::getNearestParam(const TVec3f& rPos, f32 delta) const {
     for (f32 t = 0.0f; t <= 1.0f; t += delta) {
         TVec3f pos;
         calcPos(&pos, t);
-        f32 mag = JMathInlineVEC::PSVECSquareDistance(&pos, &rPos);
+        f32 mag = pos.squared(rPos);
         if (mag < nearestMag) {
             nearestParam = t;
             nearestMag = mag;

--- a/src/Game/Map/RailPart.cpp
+++ b/src/Game/Map/RailPart.cpp
@@ -77,7 +77,7 @@ f32 LinearRailPart::getNearestParam(const register TVec3f& rPos, f32 t) const {
     TVec3f v = rPos;
     v -= mStart;
 
-    f32 proj = v.dot(mCtrlDegree1) / mCtrlDegree1.squareMag();
+    f32 proj = v.dot(mCtrlDegree1) / mCtrlDegree1.squared();
 
     if (proj < 0.0f) {
         return 0.0f;

--- a/src/Game/MapObj/LavaSteam.cpp
+++ b/src/Game/MapObj/LavaSteam.cpp
@@ -104,7 +104,7 @@ void LavaSteam::attackSensor(HitSensor* pSender, HitSensor* pReceiver) {
                 TVec3f stack_20;
                 stack_20.set(pReceiver->mPosition);
 
-                f32 dist = JMathInlineVEC::PSVECSquareDistance((Vec*)&stack_48, (Vec*)&stack_20);
+                f32 dist = stack_48.squared(stack_20);
                 f32 s = (stack_54 + f31);
                 stack_2C = f31;
 


### PR DESCRIPTION
- converted `PSVecSquareDistance` -> `TVec3::squared(const TVec3&)`
- converted `PSVecSquareMag` -> `TVec3::squared`
- converted `TVec3::squareMag` to `TVec3::squared`

There will be a broken match that appears in `Game/MapObj/BallOpener`, this is due to `BallOpener::receiveOtherMsg` not being written yet, so other instances of `TVec3f::squared(const TVec3f&)` are not there to un-inline the instance in `BallOpener::exeSetCenter`.

Improvement shown in `MR::turnRandomVector`  in `Game/Util/MathUtil` is unintended but of no consequence. 