### PR TITLE
`ManholeCover` quick fix

### DIFF
--- a/include/Game/MapObj/ManholeCover.hpp
+++ b/include/Game/MapObj/ManholeCover.hpp
@@ -4,7 +4,7 @@
 
 class ManholeCover : public MapObjActor {
 public:
-    ManholeCover(const char*);
+    inline ManholeCover(const char* pName) : MapObjActor(pName) {};
 
     virtual void init(const JMapInfoIter&);
     virtual bool receiveMsgPlayerAttack(u32, HitSensor*, HitSensor*);

--- a/src/Game/MapObj/ManholeCover.cpp
+++ b/src/Game/MapObj/ManholeCover.cpp
@@ -11,9 +11,6 @@ namespace NrvManholeCover {
     NEW_NERVE(HostTypeRattle, ManholeCover, Rattle);
 };  // namespace NrvManholeCover
 
-ManholeCover::ManholeCover(const char* pName) : MapObjActor(pName) {
-}
-
 void ManholeCover::init(const JMapInfoIter& rIter) {
     MapObjActor::init(rIter);
     MapObjActorInitInfo info;


### PR DESCRIPTION
PR fixes the `NameObjFactory` inline that was broken by my previous work on `ManholeCover`.