### PR TITLE
remove the vscode section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,6 @@ Building
   ninja
   ```
 
-Visual Studio Code
-==================
-
-If desired, use the recommended Visual Studio Code settings by renaming the `.vscode.example` directory to `.vscode`.
-
 Diffing
 =======
 


### PR DESCRIPTION
.vscode.example does not exist - it is already named .vscode

Not sure if this should be merged, or if the wording should be changed to say it's recommended to open the project in vscode??? 