### PR TITLE
Matching some nw4r files

### DIFF
--- a/config/RMGK01/splits.txt
+++ b/config/RMGK01/splits.txt
@@ -61,12 +61,13 @@ nw4r/db/db_console.cpp:
 
 nw4r/db/db_assert.cpp:
 	.text       start:0x8000B8C4 end:0x8000BBA0
-	.data       start:0x805635A0 end:0x80564678
+	.data       start:0x805635A0 end:0x80563610
 	.sdata      start:0x806B1620 end:0x806B1628
 	.sbss       start:0x806B2E78 end:0x806B2E80
 
 nw4r/math/math_triangular.cpp:
 	.text       start:0x8000BBA0 end:0x8000BC68
+	.data       start:0x80563620 end:0x80564630
 	.sdata2     start:0x806B7C60 end:0x806B7C68
 
 nw4r/math/math_types.cpp:
@@ -74,6 +75,7 @@ nw4r/math/math_types.cpp:
 
 nw4r/lyt/lyt_init.cpp:
 	.text       start:0x8000BCF8 end:0x8000BD4C
+	.data       start:0x80564630 end:0x80564678
 	.sdata      start:0x806B1628 end:0x806B1630
 
 nw4r/lyt/lyt_pane.cpp:
@@ -116,11 +118,12 @@ nw4r/lyt/lyt_window.cpp:
 nw4r/lyt/lyt_bounding.cpp:
 	.text       start:0x800112C4 end:0x80011370
 	.ctors      start:0x8052E818 end:0x8052E81C
-	.data       start:0x805648C8 end:0x80564998
+	.data       start:0x805648C8 end:0x80564930
 	.sbss       start:0x806B2EA8 end:0x806B2EB0
 
 nw4r/lyt/lyt_material.cpp:
 	.text       start:0x80011370 end:0x800140C8
+	.data       start:0x80564930 end:0x80564998
 	.sdata2     start:0x806B7CC8 end:0x806B7CE8
 
 nw4r/lyt/lyt_texMap.cpp:

--- a/configure.py
+++ b/configure.py
@@ -607,7 +607,7 @@ config.libs = [
         "libnw4r_db",
         [
             Object(Matching, "nw4r/db/db_console.cpp"),
-            Object(NonMatching, "nw4r/db/db_assert.cpp"),
+            Object(Matching, "nw4r/db/db_assert.cpp"),
         ],
     ),
     NWLib(
@@ -620,14 +620,14 @@ config.libs = [
     NWLib(
         "libnw4r_lyt",
         [
-            Object(NonMatching, "nw4r/lyt/lyt_init.cpp"),
-            Object(NonMatching, "nw4r/lyt/lyt_pane.cpp"),
+            Object(Matching, "nw4r/lyt/lyt_init.cpp"),
+            Object(Matching, "nw4r/lyt/lyt_pane.cpp"),
             Object(NonMatching, "nw4r/lyt/lyt_group.cpp"),
             Object(NonMatching, "nw4r/lyt/lyt_layout.cpp"),
             Object(NonMatching, "nw4r/lyt/lyt_picture.cpp"),
             Object(NonMatching, "nw4r/lyt/lyt_textBox.cpp"),
             Object(NonMatching, "nw4r/lyt/lyt_window.cpp"),
-            Object(NonMatching, "nw4r/lyt/lyt_bounding.cpp"),
+            Object(Matching, "nw4r/lyt/lyt_bounding.cpp"),
             Object(NonMatching, "nw4r/lyt/lyt_material.cpp"),
             Object(Matching, "nw4r/lyt/lyt_texMap.cpp"),
             Object(Matching, "nw4r/lyt/lyt_drawInfo.cpp"),

--- a/libs/nw4r/include/nw4r/ut/CharWriter.h
+++ b/libs/nw4r/include/nw4r/ut/CharWriter.h
@@ -131,7 +131,7 @@ namespace nw4r {
             void SetupGXForI();
             void SetupGXDefault();
             void SetupGXForRGBA();
-            void SetupGXWithColorMapping(Color, Color);
+            static void SetupGXWithColorMapping(Color, Color);
 
             void ResetTextureCache() {
                 mLoadingTexture.Reset();
@@ -149,7 +149,7 @@ namespace nw4r {
             f32 Print(CharCode);
             void PrintGlyph(f32, f32, f32, const Glyph&);
             void UpdateVertexColor();
-            void SetupVertexFormat();
+            static void SetupVertexFormat();
 
             void ResetColorMapping() {
                 SetColorMapping(0x00000000UL, 0xFFFFFFFFUL);

--- a/src/nw4r/math/math_triangular.cpp
+++ b/src/nw4r/math/math_triangular.cpp
@@ -3,7 +3,7 @@
 namespace nw4r {
     namespace math {
         namespace detail {
-            const SinCosSample gSinCosTbl[256 + 1] = {
+            SinCosSample gSinCosTbl[256 + 1] = {
                 0.000000f,  1.000000f,  0.024541f,  -0.000301f,  // rad = 0.000000, deg = 0.000000
                 0.024541f,  0.999699f,  0.024526f,  -0.000903f,  // rad = 0.024544, deg = 1.406250
                 0.049068f,  0.998795f,  0.024497f,  -0.001505f,  // rad = 0.049087, deg = 2.812500

--- a/src/nw4r/ut/ut_CharWriter.cpp
+++ b/src/nw4r/ut/ut_CharWriter.cpp
@@ -30,9 +30,6 @@ namespace nw4r {
             EnableLinearFilter(true, true);
         }
 
-        CharWriter::~CharWriter() {
-        }
-
         void CharWriter::SetColorMapping(Color min, Color max) {
             mColorMapping.min = min;
             mColorMapping.max = max;
@@ -62,27 +59,7 @@ namespace nw4r {
             }
         }
 
-        void CharWriter::SetupGXWithColorMapping(Color min, Color max) {
-            SetupGXCommon();
-            GXSetNumTevStages(2);
-            GXSetTevDirect(GX_TEVSTAGE0);
-            GXSetTevDirect(GX_TEVSTAGE1);
-            GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP0);
-            GXSetTevSwapMode(GX_TEVSTAGE1, GX_TEV_SWAP0, GX_TEV_SWAP0);
-            GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR_NULL);
-            GXSetTevColor(GX_TEVREG0, min);
-            GXSetTevColor(GX_TEVREG1, max);
-            GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_C0, GX_CC_C1, GX_CC_TEXC, GX_CC_ZERO);
-            GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_A0, GX_CA_A1, GX_CA_TEXA, GX_CA_ZERO);
-            GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
-            GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
-            GXSetTevOrder(GX_TEVSTAGE1, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
-            GXSetTevColorIn(GX_TEVSTAGE1, GX_CC_ZERO, GX_CC_CPREV, GX_CC_RASC, GX_CC_ZERO);
-            GXSetTevAlphaIn(GX_TEVSTAGE1, GX_CA_ZERO, GX_CA_APREV, GX_CA_RASA, GX_CA_ZERO);
-            GXSetTevColorOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
-            GXSetTevAlphaOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
-
-            SetupVertexFormat();
+        CharWriter::~CharWriter() {
         }
 
         void CharWriter::SetupVertexFormat() {
@@ -249,6 +226,29 @@ namespace nw4r {
             mVertexColor.ru.a = static_cast< u8 >(mVertexColor.ru.a * mAlpha / Color::ALPHA_MAX);
             mVertexColor.ld.a = static_cast< u8 >(mVertexColor.ld.a * mAlpha / Color::ALPHA_MAX);
             mVertexColor.rd.a = static_cast< u8 >(mVertexColor.rd.a * mAlpha / Color::ALPHA_MAX);
+        }
+
+        void CharWriter::SetupGXWithColorMapping(Color min, Color max) {
+            SetupGXCommon();
+            GXSetNumTevStages(2);
+            GXSetTevDirect(GX_TEVSTAGE0);
+            GXSetTevDirect(GX_TEVSTAGE1);
+            GXSetTevSwapMode(GX_TEVSTAGE0, GX_TEV_SWAP0, GX_TEV_SWAP0);
+            GXSetTevSwapMode(GX_TEVSTAGE1, GX_TEV_SWAP0, GX_TEV_SWAP0);
+            GXSetTevOrder(GX_TEVSTAGE0, GX_TEXCOORD0, GX_TEXMAP0, GX_COLOR_NULL);
+            GXSetTevColor(GX_TEVREG0, min);
+            GXSetTevColor(GX_TEVREG1, max);
+            GXSetTevColorIn(GX_TEVSTAGE0, GX_CC_C0, GX_CC_C1, GX_CC_TEXC, GX_CC_ZERO);
+            GXSetTevAlphaIn(GX_TEVSTAGE0, GX_CA_A0, GX_CA_A1, GX_CA_TEXA, GX_CA_ZERO);
+            GXSetTevColorOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+            GXSetTevAlphaOp(GX_TEVSTAGE0, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+            GXSetTevOrder(GX_TEVSTAGE1, GX_TEXCOORD_NULL, GX_TEXMAP_NULL, GX_COLOR0A0);
+            GXSetTevColorIn(GX_TEVSTAGE1, GX_CC_ZERO, GX_CC_CPREV, GX_CC_RASC, GX_CC_ZERO);
+            GXSetTevAlphaIn(GX_TEVSTAGE1, GX_CA_ZERO, GX_CA_APREV, GX_CA_RASA, GX_CA_ZERO);
+            GXSetTevColorOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+            GXSetTevAlphaOp(GX_TEVSTAGE1, GX_TEV_ADD, GX_TB_ZERO, GX_CS_SCALE_1, GX_TRUE, GX_TEVPREV);
+
+            SetupVertexFormat();
         }
     };  // namespace ut
 };  // namespace nw4r

--- a/src/nw4r/ut/ut_TextWriterBase.cpp
+++ b/src/nw4r/ut/ut_TextWriterBase.cpp
@@ -198,6 +198,10 @@ namespace nw4r {
                 CalcStringRect(&textRect, str, length);
                 textWidth = textRect.left + textRect.right;
                 textHeight = textRect.top + textRect.bottom;
+
+                if (textWidth > mWidthLimit) {
+                    textWidth = mWidthLimit;
+                }
             }
 
             if (IsDrawFlagSet(HORIZONTAL_ORIGIN_MASK, HORIZONTAL_ORIGIN_CENTER)) {


### PR DESCRIPTION
Match `db_assert`
Match `lyt_init`
Match `lyt_pane`
Match `lyt_bounding`

There is a string at `0x80563610` "%s:%d Warning:" that seems unused.