### PR TITLE
`GhostPlayer` at 99%

### DIFF
--- a/config/RMGK01/splits.txt
+++ b/config/RMGK01/splits.txt
@@ -6807,13 +6807,13 @@ Game/Player/GhostPlayer.cpp:
 	.text       start:0x802A46A8 end:0x802A684C
 	.ctors      start:0x8052F050 end:0x8052F054
 	.rodata     start:0x805398D0 end:0x80539A28
-	.data       start:0x805B75C0 end:0x805B77E0
-	.sbss       start:0x806B6260 end:0x806B6290
+	.data       start:0x805B75C0 end:0x805B77A8
+	.sbss       start:0x806B6260 end:0x806B6280
 	.sdata2     start:0x806BF3C0 end:0x806BF408
 
 Game/Player/GroupChecker.cpp:
 	.text       start:0x802A684C end:0x802A6A70
-	.data       start:0x805B77E0 end:0x805B7828
+	.data       start:0x805B77A8 end:0x805B7828
 
 Game/Player/J3DModelX.cpp:
 	.text       start:0x802A6A70 end:0x802A876C
@@ -6830,6 +6830,7 @@ Game/Player/MarineSnow.cpp:
 	.text       start:0x802A895C end:0x802A9178
 	.rodata     start:0x80539A28 end:0x80539A38
 	.data       start:0x805B78D0 end:0x805B78E0
+	.sbss       start:0x806B6280 end:0x806B6288
 	.sdata2     start:0x806BF428 end:0x806BF458
 
 Game/Player/Mario.cpp:
@@ -6846,6 +6847,7 @@ Game/Player/MarioActor.cpp:
 	.rodata     start:0x80539A40 end:0x80539A58
 	.data       start:0x805B7AC0 end:0x805B8138
 	.sdata      start:0x806B2210 end:0x806B2218
+	.sbss       start:0x806B6288 end:0x806B6290
 	.sdata2     start:0x806BF528 end:0x806BF618
 
 Game/Player/MarioActorDraw.cpp:

--- a/include/Game/Animation/XanimeCore.hpp
+++ b/include/Game/Animation/XanimeCore.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <JSystem/J3DGraphAnimator/J3DMtxCalc.hpp>
+#include <JSystem/J3DGraphAnimator/J3DJoint.hpp>
 #include <JSystem/JGeometry/TVec.hpp>
 
 class J3DModelData;

--- a/include/Game/Player/GhostPlayer.hpp
+++ b/include/Game/Player/GhostPlayer.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Game/LiveActor/LiveActor.hpp"
-#include <JSystem/JGeometry/TVec.hpp>
 
 class ActorCameraInfo;
 class CameraTargetMtx;
@@ -21,7 +20,7 @@ namespace MR {
     void convToFloat(TVec3Sc&, s8, TVec3f*);
     void convToFloat(s16, s8, f32*);
     void convToFloat(s8, s8, f32*);
-}  // namespace MR
+};  // namespace MR
 
 class GhostPlayer : public LiveActor {
 public:

--- a/include/Game/Player/GhostPlayer.hpp
+++ b/include/Game/Player/GhostPlayer.hpp
@@ -28,7 +28,6 @@ public:
 
     GhostPlayer(const char*);
 
-    virtual ~GhostPlayer();
     virtual void init(const JMapInfoIter&);
     virtual void draw() const;
     virtual void appear();

--- a/include/Game/Player/GhostPlayer.hpp
+++ b/include/Game/Player/GhostPlayer.hpp
@@ -1,16 +1,80 @@
 #pragma once
 
 #include "Game/LiveActor/LiveActor.hpp"
+#include <JSystem/JGeometry/TVec.hpp>
 
-class NameObjArchiveListCollector;
+class ActorCameraInfo;
+class CameraTargetMtx;
+class FixedPosition;
+class GhostPacket;
+class HitSensor;
 class JMapInfoIter;
+class JetTurtleShadow;
+class NameObjArchiveListCollector;
+class RaceManagerLayout;
+class XanimePlayer;
+
+f32 getShiftRatio(s8 shiftValue);
+
+namespace MR {
+    void convToFloat(TVec3s&, s8, TVec3f*);
+    void convToFloat(TVec3Sc&, s8, TVec3f*);
+    void convToFloat(s16, s8, f32*);
+    void convToFloat(s8, s8, f32*);
+}  // namespace MR
 
 class GhostPlayer : public LiveActor {
 public:
-    GhostPlayer(const char*);
-    virtual ~GhostPlayer();
     static void makeArchiveList(NameObjArchiveListCollector*, const JMapInfoIter&);
 
-private:
-    u8 mPad[(0x134) - sizeof(LiveActor)];
+    GhostPlayer(const char*);
+
+    virtual ~GhostPlayer();
+    virtual void init(const JMapInfoIter&);
+    virtual void draw() const;
+    virtual void appear();
+    virtual void control();
+    virtual void calcAndSetBaseMtx();
+    virtual void attackSensor(HitSensor*, HitSensor*);
+    virtual bool receiveMsgPlayerAttack(u32, HitSensor*, HitSensor*);
+    virtual bool receiveOtherMsg(u32, HitSensor*, HitSensor*);
+
+    void exeWait();
+    void warpPosition(const char*);
+    void exePreStartDemo0();
+    bool isRequestSkipDemo() const;
+    void exePreStartDemo1();
+    void exePreStartDemo2();
+    void exeWinDemo();
+    void exeLostDemo();
+    void initAnimation();
+    void setAnimation(const char*);
+    void setAnimationWeight(const f32*);
+    u32 receiveGhostPacket(GhostPacket*);
+
+    /* 0x08C */ u32 _8C;
+    /* 0x090 */ u32 _90;
+    /* 0x094 */ ActorCameraInfo* mCameraInfo;
+    /* 0x098 */ XanimePlayer* mXanimePlayer;
+    /* 0x09C */ XanimePlayer* mXanimePlayerUpper;
+    /* 0x0A0 */ Mtx mTargetRotationMtx;
+    /* 0x0D0 */ f32 mAnimTrackWeights[4];
+    /* 0x0E0 */ TVec3f mStartPos;
+    /* 0x0EC */ u32 _EC[3];  // unused
+    /* 0x0F8 */ TVec3f mTargetRotation;
+    /* 0x104 */ TVec3f mInitialDirection;
+    /* 0x110 */ bool mIsHidden;
+    /* 0x111 */ bool mWaitingToStart;
+    /* 0x112 */ bool _112;
+    /* 0x113 */ bool mKilledByStar;
+    /* 0x114 */ bool mIsDemoCameraActive;
+    /* 0x115 */ bool mHasJetTurtle;
+    /* 0x118 */ LiveActor* mPowerStarTarget;
+    /* 0x11C */ JetTurtleShadow* mJetTurtleShadow;
+    /* 0x120 */ FixedPosition* mHandRPos;
+    /* 0x124 */ u16 mAppearStarPieceCooldown;
+    /* 0x126 */ u16 mPlayerTrampleCooldown;
+    /* 0x128 */ GhostPacket* mCurrentPacket;
+    /* 0x12C */ RaceManagerLayout* mRaceManagerLayout;
+    /* 0x130 */ CameraTargetMtx* mCameraTargetMtx;
 };

--- a/libs/JSystem/include/JSystem/JGeometry/TVec.hpp
+++ b/libs/JSystem/include/JSystem/JGeometry/TVec.hpp
@@ -219,6 +219,9 @@ namespace JGeometry {
         T y;
         T z;
 
+        inline TVec3() {
+        }
+
         TVec3< T >(T _x, T _y, T _z) {
             x = _x;
             y = _y;

--- a/libs/JSystem/include/JSystem/JGeometry/TVec.hpp
+++ b/libs/JSystem/include/JSystem/JGeometry/TVec.hpp
@@ -219,7 +219,7 @@ namespace JGeometry {
         T y;
         T z;
 
-        inline TVec3() {
+        TVec3() {
         }
 
         TVec3< T >(T _x, T _y, T _z) {

--- a/src/Game/Player/GhostPlayer.cpp
+++ b/src/Game/Player/GhostPlayer.cpp
@@ -1,12 +1,116 @@
 #include "Game/Player/GhostPlayer.hpp"
+#include "Game/Animation/XanimeCore.hpp"
+#include "Game/Animation/XanimePlayer.hpp"
+#include "Game/Camera/CameraTargetArg.hpp"
+#include "Game/Camera/CameraTargetMtx.hpp"
+#include "Game/LiveActor/HitSensor.hpp"
+#include "Game/LiveActor/ModelManager.hpp"
+#include "Game/LiveActor/Nerve.hpp"
+#include "Game/Map/RaceManager.hpp"
 #include "Game/NameObj/NameObjArchiveListCollector.hpp"
-#include "Game/Util.hpp"
-#include <cstring>
+#include "Game/Player/GhostPacket.hpp"
+#include "Game/Player/J3DModelX.hpp"
+#include "Game/Player/JetTurtleShadow.hpp"
+#include "Game/Scene/SceneFunction.hpp"
+#include "Game/Util/ActorCameraUtil.hpp"
+#include "Game/Util/ActorMovementUtil.hpp"
+#include "Game/Util/ActorSensorUtil.hpp"
+#include "Game/Util/ActorShadowUtil.hpp"
+#include "Game/Util/ActorSwitchUtil.hpp"
+#include "Game/Util/DemoUtil.hpp"
+#include "Game/Util/EffectUtil.hpp"
+#include "Game/Util/EventUtil.hpp"
+#include "Game/Util/FileUtil.hpp"
+#include "Game/Util/FixedPosition.hpp"
+#include "Game/Util/GamePadUtil.hpp"
+#include "Game/Util/JMapUtil.hpp"
+#include "Game/Util/JointUtil.hpp"
+#include "Game/Util/LiveActorUtil.hpp"
+#include "Game/Util/MathUtil.hpp"
+#include "Game/Util/ModelUtil.hpp"
+#include "Game/Util/MtxUtil.hpp"
+#include "Game/Util/ObjUtil.hpp"
+#include "Game/Util/PlayerUtil.hpp"
+#include "Game/Util/SceneUtil.hpp"
+#include "Game/Util/SequenceUtil.hpp"
+#include "Game/Util/SoundUtil.hpp"
+#include "Game/Util/StringUtil.hpp"
+#include <cstdio>
 
-GhostPlayer::GhostPlayer(const char* pName) : LiveActor(pName) {
+void GhostPlayer_FORCE_MATCH_SDATA2() {
+    (void)1.0f;
+    (void)0.0f;
 }
-GhostPlayer::~GhostPlayer() {
-}
+
+namespace {
+    struct AnimSoundInfo {
+        /* 0x00 */ const char* pAnimName;
+        /* 0x04 */ const char* pSoundBM;
+        /* 0x08 */ const char* pSoundBV;
+    };
+
+    const AnimSoundInfo sAnimSoundTable[28] = {{"ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
+                                               {"ジャンプB", "SE_BM_GHOST_MARIO_JUMP_M", "SE_BV_GHOST_MARIO_JUMP_M"},
+                                               {"ジャンプC", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
+                                               {"壁ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
+                                               {"埋まり脱出ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
+                                               {"幅とび", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
+                                               {"しゃがみジャンプ", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
+                                               {"崖つかまり開始", nullptr, "SE_BV_GHOST_MARIO_HANG"},
+                                               {"崖つかまり終了", nullptr, "SE_BV_GHOST_MARIO_CLIMB"},
+                                               {"壁押し", nullptr, "SE_BV_GHOST_MARIO_HANG"},
+                                               {"ヒップドロップ開始", "SE_BM_GHOST_MARIO_HIP_DROP_TURN", "SE_BV_GHOST_MARIO_HIPDROP_S"},
+                                               {"ヒップドロップ着地", "SE_BM_GHOST_MARIO_HIP_DROP_LAND", "SE_BV_GHOST_MARIO_HIPDROP_E"},
+                                               {"埋まり脱出ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
+                                               {"水泳スピン", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                               {"水泳ジェット開始", nullptr, "SE_BV_GHOST_MARIO_SWM_ACCEL"},
+                                               {"カメ持ちリング準備", nullptr, "SE_BV_GHOST_MARIO_TAKE"},
+                                               {"カメ持ちリング", nullptr, "SE_BV_GHOST_MARIO_SWM_ACCEL"},
+                                               {"投げ", nullptr, "SE_BV_GHOST_MARIO_THROW"},
+                                               {"空中ひねり", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                               {"地上ひねり", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                               {"空パンチ", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                               {"アイスひねり", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                               {"アイスひねり移動", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                               {"スケートアクセルジャンプ", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
+                                               {"スケートジャンプ2", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
+                                               {"氷上力行右", nullptr, "SE_BV_GHOST_MARIO_JUMP_S"},
+                                               {"氷上力行左", nullptr, "SE_BV_GHOST_MARIO_JUMP_S"},
+                                               {"ショートジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"}};
+
+    static inline const AnimSoundInfo* getAnimSoundInfo(const char* pAnimName) {
+        for (u32 i = 0; i < ARRAY_SIZE(sAnimSoundTable); i++) {
+            if (MR::isEqualString(pAnimName, sAnimSoundTable[i].pAnimName)) {
+                return &sAnimSoundTable[i];
+            }
+        }
+        return nullptr;
+    }
+
+    void playSound(LiveActor* pActor, const char* pAnimName) {
+        const AnimSoundInfo* matchedEntry = getAnimSoundInfo(pAnimName);
+
+        if (matchedEntry != nullptr) {
+            if (matchedEntry->pSoundBM != nullptr) {
+                MR::startSound(pActor, matchedEntry->pSoundBM);
+            }
+            if (matchedEntry->pSoundBV != nullptr) {
+                MR::startSound(pActor, matchedEntry->pSoundBV);
+            }
+        }
+    }
+};  // namespace
+
+namespace NrvGhostPlayer {
+    NEW_NERVE(HostTypeNrvWait, GhostPlayer, Wait);
+    NEW_NERVE(HostTypeNrvWinDemo, GhostPlayer, WinDemo);
+    NEW_NERVE(HostTypeNrvLostDemo, GhostPlayer, LostDemo);
+    NEW_NERVE(HostTypeNrvPreStartDemo0, GhostPlayer, PreStartDemo0);
+    NEW_NERVE(HostTypeNrvPreStartDemo1, GhostPlayer, PreStartDemo1);
+    NEW_NERVE(HostTypeNrvPreStartDemo2, GhostPlayer, PreStartDemo2);
+    NEW_NERVE(HostTypeNrvStartDemo, GhostPlayer, Wait);
+    NEW_NERVE(HostTypeNrvRun, GhostPlayer, Wait);
+};  // namespace NrvGhostPlayer
 
 void GhostPlayer::makeArchiveList(NameObjArchiveListCollector* pArchiveList, const JMapInfoIter&) {
     char archiveName[0x100];
@@ -20,3 +124,686 @@ void GhostPlayer::makeArchiveList(NameObjArchiveListCollector* pArchiveList, con
         pArchiveList->addArchive("GhostMario");
     }
 }
+
+GhostPlayer::GhostPlayer(const char* pName) : LiveActor(pName), _90(0), mCameraInfo(nullptr), mXanimePlayer(nullptr) {
+    _8C = 0;
+    mTargetRotation.zero();
+    mKilledByStar = false;
+    mPowerStarTarget = nullptr;
+    mHasJetTurtle = false;
+}
+
+void GhostPlayer::init(const JMapInfoIter& rIter) {
+    char gstPath[256];
+    char arcPath[256];
+
+    RaceManagerLayout* layout = new RaceManagerLayout("レース管理用レイアウト");
+    mRaceManagerLayout = layout;
+    mRaceManagerLayout->init(rIter);
+
+    mCurrentPacket = nullptr;
+    if (MR::isPlayerLuigi()) {
+        const char* currentStageName = MR::getCurrentStageName();
+        sprintf(gstPath, "%sLuigi.gst", currentStageName);
+    } else {
+        const char* currentStageName = MR::getCurrentStageName();
+        sprintf(gstPath, "%s.gst", currentStageName);
+    }
+    strcpy(arcPath, "GhostData");
+    strcat(arcPath, MR::getCurrentStageName());
+    strcat(arcPath, ".arc");
+
+    mCurrentPacket = static_cast< GhostPacket* >(MR::loadResourceFromArc(arcPath, gstPath));
+
+    if (MR::isFileExist(gstPath, false)) {
+        mCurrentPacket = static_cast< GhostPacket* >(MR::loadToMainRAM(gstPath, nullptr, nullptr, JKRDvdRipper::ALLOC_DIRECTION_FORWARD));
+    }
+
+    if (mCurrentPacket == nullptr) {
+        makeActorDead();
+        return;
+    } else {
+        if (MR::isPlayerLuigi())
+            initModelManagerWithAnm("GhostLuigi", nullptr, false);
+        else
+            initModelManagerWithAnm("GhostMario", nullptr, false);
+    }
+
+    initEffectKeeper(5, "GhostMario", false);
+    MR::connectToScene(this, MR::MovementType_Player, MR::CalcAnimType_Player, -1, MR::DrawType_Player);
+    MR::initDefaultPos(this, rIter);
+    mStartPos = mPosition;
+    mVelocity.zero();
+    initAnimation();
+    initHitSensor(1);
+    MR::addHitSensorRide(this, "body", 4, 40.0f, TVec3f(0.0f, 80.0f, 0.0f));
+    MR::initShadowVolumeSphere(this, 50.0f);
+    MR::validateShadow(this, nullptr);
+    MR::calcGravity(this);
+    MR::onCalcShadow(this, nullptr);
+    MR::onCalcShadowDropGravity(this, nullptr);
+    initSound(6, false);
+    MR::invalidateClipping(this);
+    _90 = 0;
+    mCameraInfo = nullptr;
+    if (MR::isValidInfo(rIter)) {
+        MR::initMultiActorCamera(this, rIter, &mCameraInfo, "レース開始1");
+        MR::initMultiActorCamera(this, rIter, &mCameraInfo, "レース開始2");
+        MR::initMultiActorCamera(this, rIter, &mCameraInfo, "レース開始3");
+        MR::initMultiActorCamera(this, rIter, &mCameraInfo, "レース終了");
+    }
+    mCameraTargetMtx = new CameraTargetMtx("カメラターゲットダミー");
+    initNerve(&NrvGhostPlayer::HostTypeNrvWait::sInstance);
+    MR::needStageSwitchReadAppear(this, rIter);
+    MR::syncStageSwitchAppear(this);
+    makeActorDead();
+    mWaitingToStart = true;
+    _112 = true;
+    MR::getRotatedAxisZ(&mInitialDirection, mRotation);
+    PSMTXCopy(getBaseMtx(), mTargetRotationMtx);
+    mJetTurtleShadow = new JetTurtleShadow("カメシャドウモデル");
+    mJetTurtleShadow->initWithoutIter();
+    mHandRPos = new FixedPosition(this, "HandR", TVec3f(15.59f, 42.5f, 42.93f), TVec3f(-17.05f, -0.7f, 113.55f));
+    MR::declareStarPiece(this, 50);
+    MR::declareCoin(this, 50);
+    mAppearStarPieceCooldown = 0;
+    mPlayerTrampleCooldown = 0;
+}
+
+void GhostPlayer::appear() {
+    LiveActor::appear();
+    setNerve(&NrvGhostPlayer::HostTypeNrvPreStartDemo0::sInstance);
+    mIsHidden = true;
+    MR::invalidateShadow(this, nullptr);
+    if (MR::isPlayerLuigi()) {
+        MR::startBtk(this, "GhostLuigi");
+        MR::startBrk(this, "GhostLuigi");
+    } else {
+        MR::startBtk(this, "GhostMario");
+        MR::startBrk(this, "GhostMario");
+    }
+    MR::emitEffect(this, "Shadow");
+}
+
+void GhostPlayer::control() {
+    if (!mWaitingToStart && !MR::isDead(this)) {
+        MR::startLevelSound(this, "SE_BM_LV_GHOST_MARIO_AMBIENT");
+        if (!isNerve(&NrvGhostPlayer::HostTypeNrvLostDemo::sInstance) && !isNerve(&NrvGhostPlayer::HostTypeNrvWinDemo::sInstance)) {
+            if (!strcmp("powerstarget", MR::getPlayerCurrentBckName()) && isNerve(&NrvGhostPlayer::HostTypeNrvRun::sInstance)) {
+                setNerve(&NrvGhostPlayer::HostTypeNrvLostDemo::sInstance);
+                mKilledByStar = true;
+            } else if (mCurrentPacket) {
+                u32 packetDelayTimer = 0;
+                while (true) {
+                    GhostPacket packet(mCurrentPacket, 0);
+                    mCurrentPacket = reinterpret_cast< GhostPacket* >(reinterpret_cast< char* >(mCurrentPacket) + receiveGhostPacket(&packet));
+                    if (_112) {
+                        if (mXanimePlayer->_10[3] > 0.9f)
+                            continue;
+
+                        _112 = false;
+                        packetDelayTimer = 10;
+                        continue;
+                    }
+
+                    if (packetDelayTimer == 0)
+                        break;
+                    packetDelayTimer--;
+                }
+                if (mAppearStarPieceCooldown)
+                    mAppearStarPieceCooldown--;
+                if (mPlayerTrampleCooldown)
+                    mPlayerTrampleCooldown--;
+            }
+        }
+    }
+}
+
+void GhostPlayer::exeWait() {
+    if (mRaceManagerLayout->isAllAnimStopped())
+        mRaceManagerLayout->kill();
+}
+
+void GhostPlayer::warpPosition(const char* pName) {
+    MR::findNamePos(pName, getBaseMtx());
+    PSMTXCopy(getBaseMtx(), mTargetRotationMtx);
+    MR::extractMtxTrans(getBaseMtx(), &mPosition);
+}
+
+void GhostPlayer::exePreStartDemo0() {
+    if (MR::isFirstStep(this)) {
+        MR::startSound(this, "SE_BM_GHOST_MARIO_APPEAR");
+        MR::startSound(this, "SE_BV_GHOST_MARIO_APPEAR");
+        MR::offPlayerControl();
+        TPos3f* cameraTargetMatrix = &mCameraTargetMtx->mMatrix;
+        cameraTargetMatrix->set(getBaseMtx());
+
+        MR::startMultiActorCameraTargetOther(this, mCameraInfo, "レース開始1", CameraTargetArg(mCameraTargetMtx), -1);
+        warpPosition("ゴーストデモゴースト位置");
+    }
+
+    if (getNerveStep() == 1) {
+        Mtx playerPosMtx;
+        TVec3f playerPosVec;
+
+        MR::findNamePos("ゴーストデモマリオ位置", playerPosMtx);
+        MR::extractMtxTrans(playerPosMtx, &playerPosVec);
+        MR::setPlayerPosAndWait(playerPosVec);
+        MR::setPlayerBaseMtx(playerPosMtx);
+        MR::startBckPlayerJ("レース見る");
+        MR::resetPlayerEffect();
+        MR::tryStartDemo(this, "レース準備");
+        MR::requestMovementOn(this);
+        MR::requestMovementOnPlayer();
+    }
+    if (getNerveStep() == 0x3C) {
+        mIsHidden = false;
+        setAnimation("ゴースト出現");
+        MR::validateShadow(this, nullptr);
+    }
+    if (getNerveStep() == 0x6B) {
+        MR::startSound(this, "SE_BV_GHOST_MARIO_LAND");
+    }
+    if (getNerveStep() == 0x6F) {
+        MR::startSound(this, "SE_BM_GHOST_MARIO_LAND");
+    }
+    if (getNerveStep() == 0x92) {
+        MR::startSound(this, "SE_BV_GHOST_MARIO_PROVOKE");
+    }
+    if (getNerveStep() == 0xF0) {
+        MR::endMultiActorCamera(this, mCameraInfo, "レース開始1", false, -1);
+        TPos3f* cameraTargetMatrix = &mCameraTargetMtx->mMatrix;
+        cameraTargetMatrix->set(getBaseMtx());
+        MR::startMultiActorCameraTargetOther(this, mCameraInfo, "レース開始2", CameraTargetArg(mCameraTargetMtx), -1);
+        setNerve(&NrvGhostPlayer::HostTypeNrvPreStartDemo1::sInstance);
+        setAnimation("レース見る");
+    } else if (isRequestSkipDemo()) {
+        MR::endMultiActorCamera(this, mCameraInfo, "レース開始1", false, -1);
+        MR::startMultiActorCameraTargetSelf(this, mCameraInfo, "レース開始3", -1);
+        setNerve(&NrvGhostPlayer::HostTypeNrvPreStartDemo2::sInstance);
+        if (getNerveStep() < 0x3C) {
+            mIsHidden = false;
+            setAnimation("ゴースト出現");
+            MR::validateShadow(this, nullptr);
+        }
+    }
+}
+
+bool GhostPlayer::isRequestSkipDemo() const {
+    if (MR::hasRetryGalaxySequence() && MR::testCorePadTriggerA(0))
+        return true;
+    return false;
+}
+
+void GhostPlayer::exePreStartDemo1() {
+    if (getNerveStep() == 0xF0) {
+        MR::endMultiActorCamera(this, mCameraInfo, "レース開始2", false, -1);
+        MR::startMultiActorCameraTargetSelf(this, mCameraInfo, "レース開始3", -1);
+        setNerve(&NrvGhostPlayer::HostTypeNrvPreStartDemo2::sInstance);
+    } else if (isRequestSkipDemo()) {
+        MR::endMultiActorCamera(this, mCameraInfo, "レース開始2", false, -1);
+        MR::startMultiActorCameraTargetSelf(this, mCameraInfo, "レース開始3", -1);
+        setNerve(&NrvGhostPlayer::HostTypeNrvPreStartDemo2::sInstance);
+    }
+}
+
+void GhostPlayer::exePreStartDemo2() {
+    if (MR::isFirstStep(this)) {
+        mRaceManagerLayout->setTime(0);
+        mRaceManagerLayout->appear();
+        mRaceManagerLayout->playCountAndGo();
+        mRaceManagerLayout->hideRecordPane();
+        mRaceManagerLayout->hideBestRecordPane();
+        setAnimation("ゴーストレース開始");
+        MR::startBckPlayerJ("レース開始");
+
+        Mtx raceStartMarioPos;
+        MR::findNamePos("レース開始時マリオ位置", raceStartMarioPos);
+        MR::setPlayerBaseMtx(raceStartMarioPos);
+
+        mPosition = mStartPos;
+        MR::endDemo(this, "レース準備");
+    }
+
+    if (MR::getPlayerTriggerZ()) {
+        MR::startBckPlayerJ("レースクラウチング開始");
+        MR::startSoundPlayer("SE_PV_SQUAT", -1);
+    } else if (MR::testSubPadReleaseZ(0)) {
+        MR::startBckPlayerJ("レース開始");
+    }
+
+    if (getNerveStep() % 60 == 0) {
+        MR::startSystemSE("SE_SY_RACE_COUNT_DOWN");
+    }
+
+    TVec3f normalizedFrontVec = mInitialDirection;
+    TVec3f upVec;
+    TVec3f frontVec;
+
+    bool isNormalized = MR::normalizeOrZero(&normalizedFrontVec);
+    TPos3f* baseMtx = reinterpret_cast< TPos3f* >(getBaseMtx());
+    baseMtx->getYDir(upVec);
+    if (!isNormalized) {
+        MR::calcFrontVec(&frontVec, this);
+        if (MR::vecBlendSphere(frontVec, normalizedFrontVec, &frontVec, 0.1f) == false) {
+            frontVec = normalizedFrontVec;
+        }
+        MR::makeMtxUpFront(reinterpret_cast< TPos3f* >(getBaseMtx()), upVec, frontVec);
+        PSMTXCopy(getBaseMtx(), mTargetRotationMtx);
+        MR::extractMtxTrans(getBaseMtx(), &mPosition);
+    }
+    if (!mRaceManagerLayout->isPlayCountAnim()) {
+        mWaitingToStart = false;
+        MR::startSound(this, "SE_BV_GHOST_MARIO_RUN_START");
+        setNerve(&NrvGhostPlayer::HostTypeNrvRun::sInstance);
+        MR::onPlayerControl(true);
+        MR::noticePlayerDashChance();
+        MR::startBckPlayerJ("基本");
+        MR::startSystemSE("SE_SY_RACE_START");
+        MR::endMultiActorCamera(this, mCameraInfo, "レース開始3", false, -1);
+    }
+}
+
+void GhostPlayer::exeWinDemo() {
+    if (MR::isFirstStep(this)) {
+        MR::offPlayerControl();
+        MR::tryPlayerKillTakingActor();
+        MR::readyPlayerDemo();
+
+        TVec3f playerPosVec;
+        Mtx playerPosMtx;
+        MR::findNamePos("負け時マリオ位置", playerPosMtx);
+        MR::extractMtxTrans(playerPosMtx, &playerPosVec);
+        MR::setPlayerPosAndWait(playerPosVec);
+        MR::setPlayerBaseMtx(playerPosMtx);
+
+        MR::startBckPlayerJ("レース見る");
+        MR::startMultiActorCameraTargetSelf(this, mCameraInfo, "レース終了", -1);
+        mIsDemoCameraActive = true;
+
+        HitSensor* sensorBody = getSensor("body");
+        for (int i = 0; i < sensorBody->mSensorCount; i++) {
+            HitSensor* sensor = sensorBody->mSensors[i];
+            if (sensor->mType == ATYPE_POWER_STAR_BIND) {
+                mPowerStarTarget = sensor->mHost;
+                mPosition = sensor->mHost->mPosition;
+            }
+        }
+
+        MR::startSubBGM("BGM_RACE_LOSE", false);
+        mRaceManagerLayout->appear();
+        mRaceManagerLayout->playLose();
+        setAnimation("ゴースト勝利");
+        MR::startSound(this, "SE_BV_GHOST_MARIO_WIN");
+        MR::tryStartDemo(this, "レース終了");
+        MR::requestMovementOn(this);
+        MR::requestMovementOnPlayer();
+        if (mPowerStarTarget)
+            MR::requestMovementOn(mPowerStarTarget);
+    }
+
+    if (mPowerStarTarget) {
+        PSMTXCopy(mPowerStarTarget->getBaseMtx(), getBaseMtx());
+        PSMTXCopy(getBaseMtx(), mTargetRotationMtx);
+        MR::extractMtxTrans(getBaseMtx(), &mPosition);
+    }
+
+    if (MR::isStep(this, 0xB4)) {
+        if (mIsDemoCameraActive) {
+            MR::endMultiActorCamera(this, mCameraInfo, "レース終了", true, -1);
+            mIsDemoCameraActive = false;
+        }
+        MR::endDemo(this, "レース終了");
+        MR::forceKillPlayerByGhostRace();
+    }
+}
+
+void GhostPlayer::exeLostDemo() {
+    if (MR::isFirstStep(this)) {
+        warpPosition("負け時マリオ位置");
+        mXanimePlayer->changeAnimation("DieSwimEvent");
+        mVelocity.zero();
+        setAnimation("レース負け");
+    }
+}
+
+void GhostPlayer::calcAndSetBaseMtx() {
+    if (!MR::isDead(this)) {
+        J3DModel* model = MR::getJ3DModel(this);
+        MtxPtr baseMtx = model->getBaseTRMtx();
+
+        MR::blendMtxRotate(getBaseMtx(), mTargetRotationMtx, 0.2f, baseMtx);
+        MR::setMtxTrans(baseMtx, mPosition.x, mPosition.y, mPosition.z);
+        MR::getJ3DModel(this)->setBaseScale(mScale);
+
+        if (mHasJetTurtle) {
+            mHandRPos->calc();
+            mJetTurtleShadow->calcType0(mHandRPos->mMtx);
+        }
+    }
+}
+
+void GhostPlayer::initAnimation() {
+    XanimeResourceTable* pResource = MR::getPlayerXanimeResource();
+
+    mAnimTrackWeights[0] = 0.0f;
+    mAnimTrackWeights[1] = 0.0f;
+    mAnimTrackWeights[2] = 0.0f;
+    mAnimTrackWeights[3] = 1.0f;
+
+    mXanimePlayer = new XanimePlayer(MR::getJ3DModel(this), pResource);
+    mXanimePlayer->duplicateSimpleGroup();
+    mModelManager->mXanimePlayer = mXanimePlayer;
+    mXanimePlayer->setDefaultAnimation("基本");
+    mXanimePlayer->getCore()->enableJointTransform(MR::getJ3DModelData(this));
+    mXanimePlayerUpper = new XanimePlayer(MR::getJ3DModel(this), pResource, mXanimePlayer);
+    mXanimePlayerUpper->changeAnimation("基本");
+}
+
+void GhostPlayer::setAnimation(const char* pName) {
+    mXanimePlayer->changeAnimation(pName);
+    if (mXanimePlayer->_20->mAttribute == 0) {
+        mXanimePlayer->_20->mAttribute = 1;
+    }
+}
+
+void GhostPlayer::setAnimationWeight(const f32* pWeight) {
+    mXanimePlayer->changeTrackWeight(0, pWeight[0]);
+    mXanimePlayer->changeTrackWeight(1, pWeight[1]);
+    mXanimePlayer->changeTrackWeight(2, pWeight[2]);
+    mXanimePlayer->changeTrackWeight(3, pWeight[3]);
+}
+
+void GhostPlayer::attackSensor(HitSensor* pSender, HitSensor* pReceiver) {
+    if (pReceiver->isType(ATYPE_POWER_STAR_BIND)) {
+        HitSensor* currentRushSensor = MR::getCurrentRushSensor();
+        if ((currentRushSensor == nullptr || !currentRushSensor->isType(ATYPE_POWER_STAR_BIND)) && (!MR::isPlayerConfrontDeath() && !mKilledByStar)) {
+            if (strcmp("powerstarget", MR::getPlayerCurrentBckName())) {
+                setNerve(&NrvGhostPlayer::HostTypeNrvWinDemo::sInstance);
+                mKilledByStar = true;
+                MR::preventPlayerRush();
+            }
+        }
+    } else {
+        if (isNerve(&NrvGhostPlayer::HostTypeNrvRun::sInstance) && MR::sendMsgPush(pReceiver, pSender) && mAppearStarPieceCooldown == 0) {
+            if (MR::appearStarPiece(this, mPosition, 1, 10.0f, 40.0f, false)) {
+                if (MR::isInWater(this, TVec3f(0.0f, 0.0f, 0.0f))) {
+                    MR::startSound(this, "SE_OJ_STAR_PIECE_BURST_W");
+                } else {
+                    MR::startSound(this, "SE_OJ_STAR_PIECE_BURST");
+                }
+            }
+            mAppearStarPieceCooldown = 5;
+        }
+        if (LiveActor::isNerve(&NrvGhostPlayer::HostTypeNrvWait::sInstance)) {
+            return;
+        }
+    }
+}
+
+bool GhostPlayer::receiveMsgPlayerAttack(u32 msg, HitSensor* pSender, HitSensor* pReceiver) {
+    if (MR::isMsgJetTurtleAttack(msg))
+        return true;
+    if (MR::isMsgPlayerTrample(msg) && mPlayerTrampleCooldown == 0) {
+        TVec3f frontVec;
+        TVec3f upVec;
+        MR::calcUpVec(&upVec, this);
+        MR::calcFrontVec(&frontVec, this);
+
+        if (MR::appearStarPiece(this, mPosition, 5, 10.0f, 40.0f, false)) {
+            if (MR::isInWater(this, TVec3f(0.0f, 0.0f, 0.0f))) {
+                MR::startSound(this, "SE_OJ_STAR_PIECE_BURST_W");
+            } else {
+                MR::startSound(this, "SE_OJ_STAR_PIECE_BURST");
+            }
+        }
+
+        mPlayerTrampleCooldown = 10;
+        return true;
+    }
+
+    return false;
+}
+
+bool GhostPlayer::receiveOtherMsg(u32 msg, HitSensor* pSender, HitSensor* pReceiver) {
+    return true;
+}
+
+void GhostPlayer::draw() const {
+    if (!MR::isDead(this) && !mIsHidden) {
+        J3DModelX* model = reinterpret_cast< J3DModelX* >(MR::getJ3DModel(this));
+        model->viewCalc2();
+        GXInvalidateVtxCache();
+        model->mFlags.clear();
+        model->directDraw(nullptr);
+        if (mHasJetTurtle)
+            mJetTurtleShadow->drawType1();
+
+        GXSetAlphaUpdate(GX_FALSE);
+        GXSetColorUpdate(GX_TRUE);
+        GXSetDstAlpha(GX_FALSE, 0);
+    }
+}
+
+u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
+    u8 frameIndex;
+    u8 bytesRead;
+    u16 updateFlags;
+
+    pPacket->read((s8*)&frameIndex);
+    pPacket->read((s8*)&bytesRead);
+    pPacket->read((s16*)&updateFlags);
+
+    GhostPacket nextPacket = GhostPacket(pPacket->mDataPtr + bytesRead, 1);
+    u8 nextFrameIndex;
+    nextPacket.read((s8*)&nextFrameIndex);
+
+    if (++frameIndex != nextFrameIndex) {
+        if (mIsDemoCameraActive && MR::isBckOneTimeAndStopped(this)) {
+            MR::endActorCamera(this, mCameraInfo, false, -1);
+            mIsDemoCameraActive = false;
+        }
+        return false;
+    }
+
+    pPacket->mCurOffs = 4;
+
+    if ((updateFlags & 1) != 0) {
+        TVec3s rawPos;
+        pPacket->read(&rawPos);
+        MR::convToFloat(rawPos, -2, &mPosition);
+    }
+
+    if ((updateFlags & 0x800) != 0) {
+        TVec3Sc rawVel;
+        pPacket->read(&rawVel);
+        MR::convToFloat(rawVel, 0, &mVelocity);
+    }
+
+    if ((updateFlags & 0x400) != 0) {
+        TVec3Sc rawScale;
+        pPacket->read(&rawScale);
+        MR::convToFloat(rawScale, 3, &mScale);
+    }
+
+    if ((updateFlags & 2) != 0) {
+        s8 rawRotX;
+        f32 rotX;
+        pPacket->read(&rawRotX);
+        MR::convToFloat(rawRotX, 7, &rotX);
+        rotX *= 180.0f;
+        rotX = MR::clamp(rotX, -180.0f, 180.0f);
+        mTargetRotation.x = rotX;
+    }
+
+    if ((updateFlags & 4) != 0) {
+        s8 rawRotY;
+        f32 rotY;
+        pPacket->read(&rawRotY);
+        MR::convToFloat(rawRotY, 7, &rotY);
+        rotY *= 180.0f;
+        rotY = MR::clamp(rotY, -180.0f, 180.0f);
+        mTargetRotation.y = rotY;
+    }
+
+    if ((updateFlags & 8) != 0) {
+        s8 rawRotZ;
+        f32 rotZ;
+        pPacket->read(&rawRotZ);
+        MR::convToFloat(rawRotZ, 7, &rotZ);
+        rotZ *= 180.0f;
+        rotZ = MR::clamp(rotZ, -180.0f, 180.0f);
+        mTargetRotation.z = rotZ;
+    }
+
+    if ((updateFlags & 0x0E) != 0) {
+        MR::makeMtxRotate(mTargetRotationMtx, mTargetRotation);
+    }
+
+    if ((updateFlags & 0x10) != 0) {
+        char* animName;
+        pPacket->read(&animName);
+        setAnimation(animName);
+        playSound(this, animName);
+
+        bool isSpecialAnim = false;
+        if (!strcmp(animName, "基本")) {
+            isSpecialAnim = true;
+            setAnimationWeight(&mAnimTrackWeights[0]);
+        } else if (!strcmp(animName, "壁押し")) {
+            isSpecialAnim = true;
+        } else if (!strcmp(animName, "しゃがみ歩き")) {
+            isSpecialAnim = true;
+        } else if (!strcmp(animName, "がんばり走り")) {
+            isSpecialAnim = true;
+        }
+
+        if (!isSpecialAnim) {
+            mXanimePlayer->_20->mAttribute = 1;
+        }
+    }
+
+    if ((updateFlags & 0x2000) != 0) {
+        u32 animHash;
+        pPacket->read(&animHash);
+        mXanimePlayer->changeAnimationByHash(animHash);
+
+        bool isSpecialAnim = false;
+        const char* currentAnimName = mXanimePlayer->getCurrentAnimationName();
+        playSound(this, currentAnimName);
+
+        if (!strcmp(currentAnimName, "基本")) {
+            isSpecialAnim = true;
+            setAnimationWeight(&mAnimTrackWeights[0]);
+        }
+        if (!strcmp(currentAnimName, "壁押し"))
+            isSpecialAnim = true;
+        if (!strcmp(currentAnimName, "しゃがみ歩き"))
+            isSpecialAnim = true;
+        if (!strcmp(currentAnimName, "がんばり走り"))
+            isSpecialAnim = true;
+        if (!strcmp(currentAnimName, "スケートアクセルジャンプ"))
+            isSpecialAnim = true;
+        if (!strcmp(currentAnimName, "スケートジャンプ2"))
+            isSpecialAnim = true;
+        if (!strcmp(currentAnimName, "スケートジャンプ3"))
+            isSpecialAnim = true;
+
+        if (strstr(currentAnimName, "水泳ジェット"))
+            mHasJetTurtle = true;
+        else if (strstr(currentAnimName, "カメ持ち"))
+            mHasJetTurtle = true;
+        else if (strstr(currentAnimName, "投げ")) {
+            mHasJetTurtle = false;
+            mXanimePlayerUpper->stopAnimation();
+            MR::getJ3DModelData(this)->getJointTree().getJointNodePointer(MR::getJointIndex(this, "Spine1"))->setMtxCalc(nullptr);
+        }
+
+        if (mHasJetTurtle && (strcmp(currentAnimName, "基本") || strcmp(currentAnimName, "ジャンプ"))) {
+            mXanimePlayerUpper->changeAnimation("ひろいウエイト");
+            mXanimePlayerUpper->overWriteMtxCalc(MR::getJointIndex(this, "PartsControl"));
+        }
+
+        if (!isSpecialAnim) {
+            mXanimePlayer->_20->mAttribute = 1;
+        }
+    }
+
+    if ((updateFlags & 0x20) != 0) {
+        s16 rawAnimFrame;
+        f32 animFrame;
+        pPacket->read(&rawAnimFrame);
+        MR::convToFloat(rawAnimFrame, 5, &animFrame);
+        MR::getBckCtrl(this)->setFrame(animFrame);
+    }
+
+    for (u32 i = 0; i < ARRAY_SIZE(mAnimTrackWeights); i++) {
+        if ((updateFlags & (0x40 << i)) != 0) {
+            s8 rawTrackWeight;
+            f32 trackWeight;
+            pPacket->read(&rawTrackWeight);
+            if ((u8)rawTrackWeight == 0x80)
+                rawTrackWeight = 0x7F;
+            MR::convToFloat(rawTrackWeight, 7, &trackWeight);
+            mXanimePlayer->changeTrackWeight(i, trackWeight);
+            mAnimTrackWeights[i] = trackWeight;
+        }
+    }
+
+    if ((updateFlags & 0x1000) != 0) {
+        s8 rawAnimRate;
+        f32 animRate;
+        pPacket->read(&rawAnimRate);
+        MR::convToFloat(rawAnimRate, 3, &animRate);
+        MR::setBckRate(this, animRate);
+    }
+
+    return bytesRead;
+}
+
+f32 getShiftRatio(s8 shiftValue) {
+    if (shiftValue > 0)
+        return static_cast< f32 >(256 << shiftValue) / 256.0f;
+    else
+        return static_cast< f32 >(256 >> -shiftValue) / 256.0f;
+}
+
+namespace MR {
+    void convToFloat(TVec3s& rInVec, s8 shiftValue, TVec3f* pOutVec) {
+        f32 factor = 1.0f / getShiftRatio(shiftValue);
+        pOutVec->x = static_cast< f32 >(rInVec.x) * factor;
+        pOutVec->y = static_cast< f32 >(rInVec.y) * factor;
+        pOutVec->z = static_cast< f32 >(rInVec.z) * factor;
+    }
+
+    void convToFloat(TVec3Sc& rInVec, s8 shiftValue, TVec3f* pOutVec) {
+        f32 factor = 1.0f / getShiftRatio(shiftValue);
+        pOutVec->x = static_cast< f32 >(rInVec.x) * factor;
+        pOutVec->y = static_cast< f32 >(rInVec.y) * factor;
+        pOutVec->z = static_cast< f32 >(rInVec.z) * factor;
+    }
+
+    void convToFloat(s16 inShort, s8 shiftValue, f32* pOutFloat) {
+        f32 factor = 1.0f / getShiftRatio(shiftValue);
+        *pOutFloat = static_cast< f32 >(inShort) * factor;
+    }
+
+    void convToFloat(s8 inS8, s8 shiftValue, f32* pOutFloat) {
+        f32 factor = 1.0f / getShiftRatio(shiftValue);
+        *pOutFloat = static_cast< f32 >(inS8) * factor;
+    }
+}  // namespace MR
+
+GhostPlayer::~GhostPlayer() {
+}
+
+// Unused; Unknown data structure
+struct BallData {
+    f32 value1;
+    u32 value2;
+};
+BallData ballData[30] = {{0.0f, 0x00000000},  {0.0f, 0x00000000}, {0.0f, 0x00000000}, {0.0f, 0xFFFFFFFF},  {8.0f, 0x0000FFC0},  {0.0f, 0x0000FFC0},
+                         {10.0f, 0xFF00FFFF}, {8.0f, 0x0000FFC0}, {0.0f, 0x0000FFC0}, {10.0f, 0xFF00FFFF}, {10.0f, 0x000000FF}, {6.0f, 0x000000FF},
+                         {15.0f, 0xFFFF40FF}, {0.0f, 0x00000000}, {0.0f, 0x00000000}, {0.0f, 0x00000000},  {0.0f, 0x00000000},  {0.0f, 0x00000000},
+                         {0.0f, 0x00000000},  {0.0f, 0xFF0000C0}, {6.0f, 0xFF0000C0}, {6.0f, 0xFF0000C0},  {0.0f, 0xFF0000C0},  {10.0f, 0xFF0000FF},
+                         {0.0f, 0xFF0000C0},  {6.0f, 0xFF0000C0}, {6.0f, 0xFF0000C0}, {0.0f, 0xFF0000C0},  {10.0f, 0xFF0000FF}, {0.0f, 0x00000000}};

--- a/src/Game/Player/GhostPlayer.cpp
+++ b/src/Game/Player/GhostPlayer.cpp
@@ -252,7 +252,7 @@ void GhostPlayer::control() {
             GhostPacket packet(mCurrentPacket, 0);
             mCurrentPacket = reinterpret_cast< GhostPacket* >(reinterpret_cast< char* >(mCurrentPacket) + receiveGhostPacket(&packet));
             if (_112) {
-                if (mXanimePlayer->_10[3] > 0.9f) {
+                if (mXanimePlayer->mWeights[3] > 0.9f) {
                     continue;
                 }
                 _112 = false;

--- a/src/Game/Player/GhostPlayer.cpp
+++ b/src/Game/Player/GhostPlayer.cpp
@@ -78,7 +78,7 @@ namespace {
                                              {"氷上力行左", nullptr, "SE_BV_GHOST_MARIO_JUMP_S"},
                                              {"ショートジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"}};
 
-    static inline const AnimSoundInfo* getAnimSoundInfo(const char* pAnimName) {
+    static const AnimSoundInfo* getAnimSoundInfo(const char* pAnimName) {
         for (u32 i = 0; i < ARRAY_SIZE(sAnimSoundTable); i++) {
             if (MR::isEqualString(pAnimName, sAnimSoundTable[i].pAnimName)) {
                 return &sAnimSoundTable[i];
@@ -246,7 +246,7 @@ void GhostPlayer::control() {
     if (strcmp("powerstarget", MR::getPlayerCurrentBckName()) == 0 && isNerve(&NrvGhostPlayer::HostTypeNrvRun::sInstance)) {
         setNerve(&NrvGhostPlayer::HostTypeNrvLostDemo::sInstance);
         mKilledByStar = true;
-    } else if (mCurrentPacket) {
+    } else if (mCurrentPacket != nullptr) {
         u32 packetDelayTimer = 0;
         while (true) {
             GhostPacket packet(mCurrentPacket, 0);
@@ -266,10 +266,10 @@ void GhostPlayer::control() {
             packetDelayTimer--;
         }
 
-        if (mAppearStarPieceCooldown) {
+        if (mAppearStarPieceCooldown != 0) {
             mAppearStarPieceCooldown--;
         }
-        if (mPlayerTrampleCooldown) {
+        if (mPlayerTrampleCooldown != 0) {
             mPlayerTrampleCooldown--;
         }
     }
@@ -456,12 +456,12 @@ void GhostPlayer::exeWinDemo() {
         MR::tryStartDemo(this, "レース終了");
         MR::requestMovementOn(this);
         MR::requestMovementOnPlayer();
-        if (mPowerStarTarget) {
+        if (mPowerStarTarget != nullptr) {
             MR::requestMovementOn(mPowerStarTarget);
         }
     }
 
-    if (mPowerStarTarget) {
+    if (mPowerStarTarget != nullptr) {
         PSMTXCopy(mPowerStarTarget->getBaseMtx(), getBaseMtx());
         PSMTXCopy(getBaseMtx(), mTargetRotationMtx);
         MR::extractMtxTrans(getBaseMtx(), &mPosition);
@@ -526,18 +526,18 @@ void GhostPlayer::setAnimation(const char* pName) {
     }
 }
 
-void GhostPlayer::setAnimationWeight(const f32* pWeight) {
-    mXanimePlayer->changeTrackWeight(0, pWeight[0]);
-    mXanimePlayer->changeTrackWeight(1, pWeight[1]);
-    mXanimePlayer->changeTrackWeight(2, pWeight[2]);
-    mXanimePlayer->changeTrackWeight(3, pWeight[3]);
+void GhostPlayer::setAnimationWeight(const f32* pWeights) {
+    mXanimePlayer->changeTrackWeight(0, pWeights[0]);
+    mXanimePlayer->changeTrackWeight(1, pWeights[1]);
+    mXanimePlayer->changeTrackWeight(2, pWeights[2]);
+    mXanimePlayer->changeTrackWeight(3, pWeights[3]);
 }
 
 void GhostPlayer::attackSensor(HitSensor* pSender, HitSensor* pReceiver) {
     if (pReceiver->isType(ATYPE_POWER_STAR_BIND)) {
         HitSensor* currentRushSensor = MR::getCurrentRushSensor();
         if ((currentRushSensor == nullptr || !currentRushSensor->isType(ATYPE_POWER_STAR_BIND)) && (!MR::isPlayerConfrontDeath() && !mKilledByStar)) {
-            if (strcmp("powerstarget", MR::getPlayerCurrentBckName())) {
+            if (strcmp("powerstarget", MR::getPlayerCurrentBckName()) != 0) {
                 setNerve(&NrvGhostPlayer::HostTypeNrvWinDemo::sInstance);
                 mKilledByStar = true;
                 MR::preventPlayerRush();
@@ -634,25 +634,25 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
 
     pPacket->mCurOffs = 4;
 
-    if ((updateFlags & 1) != 0) {
+    if ((updateFlags & 0x0001) != 0) {
         TVec3s rawPos;
         pPacket->read(&rawPos);
         MR::convToFloat(rawPos, -2, &mPosition);
     }
 
-    if ((updateFlags & 0x800) != 0) {
+    if ((updateFlags & 0x0800) != 0) {
         TVec3Sc rawVel;
         pPacket->read(&rawVel);
         MR::convToFloat(rawVel, 0, &mVelocity);
     }
 
-    if ((updateFlags & 0x400) != 0) {
+    if ((updateFlags & 0x0400) != 0) {
         TVec3Sc rawScale;
         pPacket->read(&rawScale);
         MR::convToFloat(rawScale, 3, &mScale);
     }
 
-    if ((updateFlags & 2) != 0) {
+    if ((updateFlags & 0x0002) != 0) {
         s8 rawRotX;
         f32 rotX;
         pPacket->read(&rawRotX);
@@ -662,7 +662,7 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
         mTargetRotation.x = rotX;
     }
 
-    if ((updateFlags & 4) != 0) {
+    if ((updateFlags & 0x0004) != 0) {
         s8 rawRotY;
         f32 rotY;
         pPacket->read(&rawRotY);
@@ -672,7 +672,7 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
         mTargetRotation.y = rotY;
     }
 
-    if ((updateFlags & 8) != 0) {
+    if ((updateFlags & 0x0008) != 0) {
         s8 rawRotZ;
         f32 rotZ;
         pPacket->read(&rawRotZ);
@@ -682,11 +682,11 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
         mTargetRotation.z = rotZ;
     }
 
-    if ((updateFlags & 0x0E) != 0) {
+    if ((updateFlags & 0x000E) != 0) {
         MR::makeMtxRotate(mTargetRotationMtx, mTargetRotation);
     }
 
-    if ((updateFlags & 0x10) != 0) {
+    if ((updateFlags & 0x0010) != 0) {
         char* animName;
         pPacket->read(&animName);
         setAnimation(animName);
@@ -695,7 +695,7 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
         bool isSpecialAnim = false;
         if (strcmp(animName, "基本") == 0) {
             isSpecialAnim = true;
-            setAnimationWeight(&mAnimTrackWeights[0]);
+            setAnimationWeight(mAnimTrackWeights);
         } else if (strcmp(animName, "壁押し") == 0) {
             isSpecialAnim = true;
         } else if (strcmp(animName, "しゃがみ歩き") == 0) {
@@ -720,7 +720,7 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
 
         if (strcmp(currentAnimName, "基本") == 0) {
             isSpecialAnim = true;
-            setAnimationWeight(&mAnimTrackWeights[0]);
+            setAnimationWeight(mAnimTrackWeights);
         }
         if (strcmp(currentAnimName, "壁押し") == 0) {
             isSpecialAnim = true;
@@ -741,17 +741,17 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
             isSpecialAnim = true;
         }
 
-        if (strstr(currentAnimName, "水泳ジェット")) {
+        if (strstr(currentAnimName, "水泳ジェット") != nullptr) {
             mHasJetTurtle = true;
-        } else if (strstr(currentAnimName, "カメ持ち")) {
+        } else if (strstr(currentAnimName, "カメ持ち") != nullptr) {
             mHasJetTurtle = true;
-        } else if (strstr(currentAnimName, "投げ")) {
+        } else if (strstr(currentAnimName, "投げ") != nullptr) {
             mHasJetTurtle = false;
             mXanimePlayerUpper->stopAnimation();
             MR::getJ3DModelData(this)->getJointTree().getJointNodePointer(MR::getJointIndex(this, "Spine1"))->setMtxCalc(nullptr);
         }
 
-        if (mHasJetTurtle && (strcmp(currentAnimName, "基本") || strcmp(currentAnimName, "ジャンプ"))) {
+        if (mHasJetTurtle && (strcmp(currentAnimName, "基本") != 0 || strcmp(currentAnimName, "ジャンプ") != 0)) {
             mXanimePlayerUpper->changeAnimation("ひろいウエイト");
             mXanimePlayerUpper->overWriteMtxCalc(MR::getJointIndex(this, "PartsControl"));
         }
@@ -761,7 +761,7 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
         }
     }
 
-    if ((updateFlags & 0x20) != 0) {
+    if ((updateFlags & 0x0020) != 0) {
         s16 rawAnimFrame;
         f32 animFrame;
         pPacket->read(&rawAnimFrame);
@@ -770,7 +770,7 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
     }
 
     for (u32 i = 0; i < ARRAY_SIZE(mAnimTrackWeights); i++) {
-        if ((updateFlags & (0x40 << i)) == 0) {
+        if ((updateFlags & (0x0040 << i)) == 0) {
             continue;
         }
 
@@ -828,9 +828,6 @@ namespace MR {
         *pOutFloat = static_cast< f32 >(inS8) * factor;
     }
 };  // namespace MR
-
-GhostPlayer::~GhostPlayer() {
-}
 
 // Unused; Unknown data structure
 struct BallData {

--- a/src/Game/Player/GhostPlayer.cpp
+++ b/src/Game/Player/GhostPlayer.cpp
@@ -49,34 +49,34 @@ namespace {
         /* 0x08 */ const char* pSoundBV;
     };
 
-    const AnimSoundInfo sAnimSoundTable[28] = {{"ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
-                                               {"ジャンプB", "SE_BM_GHOST_MARIO_JUMP_M", "SE_BV_GHOST_MARIO_JUMP_M"},
-                                               {"ジャンプC", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
-                                               {"壁ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
-                                               {"埋まり脱出ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
-                                               {"幅とび", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
-                                               {"しゃがみジャンプ", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
-                                               {"崖つかまり開始", nullptr, "SE_BV_GHOST_MARIO_HANG"},
-                                               {"崖つかまり終了", nullptr, "SE_BV_GHOST_MARIO_CLIMB"},
-                                               {"壁押し", nullptr, "SE_BV_GHOST_MARIO_HANG"},
-                                               {"ヒップドロップ開始", "SE_BM_GHOST_MARIO_HIP_DROP_TURN", "SE_BV_GHOST_MARIO_HIPDROP_S"},
-                                               {"ヒップドロップ着地", "SE_BM_GHOST_MARIO_HIP_DROP_LAND", "SE_BV_GHOST_MARIO_HIPDROP_E"},
-                                               {"埋まり脱出ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
-                                               {"水泳スピン", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
-                                               {"水泳ジェット開始", nullptr, "SE_BV_GHOST_MARIO_SWM_ACCEL"},
-                                               {"カメ持ちリング準備", nullptr, "SE_BV_GHOST_MARIO_TAKE"},
-                                               {"カメ持ちリング", nullptr, "SE_BV_GHOST_MARIO_SWM_ACCEL"},
-                                               {"投げ", nullptr, "SE_BV_GHOST_MARIO_THROW"},
-                                               {"空中ひねり", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
-                                               {"地上ひねり", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
-                                               {"空パンチ", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
-                                               {"アイスひねり", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
-                                               {"アイスひねり移動", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
-                                               {"スケートアクセルジャンプ", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
-                                               {"スケートジャンプ2", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
-                                               {"氷上力行右", nullptr, "SE_BV_GHOST_MARIO_JUMP_S"},
-                                               {"氷上力行左", nullptr, "SE_BV_GHOST_MARIO_JUMP_S"},
-                                               {"ショートジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"}};
+    const AnimSoundInfo sAnimSoundTable[] = {{"ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
+                                             {"ジャンプB", "SE_BM_GHOST_MARIO_JUMP_M", "SE_BV_GHOST_MARIO_JUMP_M"},
+                                             {"ジャンプC", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
+                                             {"壁ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
+                                             {"埋まり脱出ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
+                                             {"幅とび", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
+                                             {"しゃがみジャンプ", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
+                                             {"崖つかまり開始", nullptr, "SE_BV_GHOST_MARIO_HANG"},
+                                             {"崖つかまり終了", nullptr, "SE_BV_GHOST_MARIO_CLIMB"},
+                                             {"壁押し", nullptr, "SE_BV_GHOST_MARIO_HANG"},
+                                             {"ヒップドロップ開始", "SE_BM_GHOST_MARIO_HIP_DROP_TURN", "SE_BV_GHOST_MARIO_HIPDROP_S"},
+                                             {"ヒップドロップ着地", "SE_BM_GHOST_MARIO_HIP_DROP_LAND", "SE_BV_GHOST_MARIO_HIPDROP_E"},
+                                             {"埋まり脱出ジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"},
+                                             {"水泳スピン", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                             {"水泳ジェット開始", nullptr, "SE_BV_GHOST_MARIO_SWM_ACCEL"},
+                                             {"カメ持ちリング準備", nullptr, "SE_BV_GHOST_MARIO_TAKE"},
+                                             {"カメ持ちリング", nullptr, "SE_BV_GHOST_MARIO_SWM_ACCEL"},
+                                             {"投げ", nullptr, "SE_BV_GHOST_MARIO_THROW"},
+                                             {"空中ひねり", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                             {"地上ひねり", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                             {"空パンチ", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                             {"アイスひねり", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                             {"アイスひねり移動", "SE_BM_GHOST_MARIO_SPIN", "SE_BV_GHOST_MARIO_SPIN"},
+                                             {"スケートアクセルジャンプ", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
+                                             {"スケートジャンプ2", "SE_BM_GHOST_MARIO_JUMP_L", "SE_BV_GHOST_MARIO_JUMP_L"},
+                                             {"氷上力行右", nullptr, "SE_BV_GHOST_MARIO_JUMP_S"},
+                                             {"氷上力行左", nullptr, "SE_BV_GHOST_MARIO_JUMP_S"},
+                                             {"ショートジャンプ", "SE_BM_GHOST_MARIO_JUMP_S", "SE_BV_GHOST_MARIO_JUMP_S"}};
 
     static inline const AnimSoundInfo* getAnimSoundInfo(const char* pAnimName) {
         for (u32 i = 0; i < ARRAY_SIZE(sAnimSoundTable); i++) {
@@ -89,14 +89,15 @@ namespace {
 
     void playSound(LiveActor* pActor, const char* pAnimName) {
         const AnimSoundInfo* matchedEntry = getAnimSoundInfo(pAnimName);
+        if (matchedEntry == nullptr) {
+            return;
+        }
 
-        if (matchedEntry != nullptr) {
-            if (matchedEntry->pSoundBM != nullptr) {
-                MR::startSound(pActor, matchedEntry->pSoundBM);
-            }
-            if (matchedEntry->pSoundBV != nullptr) {
-                MR::startSound(pActor, matchedEntry->pSoundBV);
-            }
+        if (matchedEntry->pSoundBM != nullptr) {
+            MR::startSound(pActor, matchedEntry->pSoundBM);
+        }
+        if (matchedEntry->pSoundBV != nullptr) {
+            MR::startSound(pActor, matchedEntry->pSoundBV);
         }
     }
 };  // namespace
@@ -113,7 +114,7 @@ namespace NrvGhostPlayer {
 };  // namespace NrvGhostPlayer
 
 void GhostPlayer::makeArchiveList(NameObjArchiveListCollector* pArchiveList, const JMapInfoIter&) {
-    char archiveName[0x100];
+    char archiveName[256];
     strcpy(archiveName, "GhostData");
     strcat(archiveName, MR::getCurrentStageName());
     pArchiveList->addArchive(archiveName);
@@ -125,7 +126,7 @@ void GhostPlayer::makeArchiveList(NameObjArchiveListCollector* pArchiveList, con
     }
 }
 
-GhostPlayer::GhostPlayer(const char* pName) : LiveActor(pName), _90(0), mCameraInfo(nullptr), mXanimePlayer(nullptr) {
+GhostPlayer::GhostPlayer(const char* pName) : LiveActor(pName), _90(), mCameraInfo(), mXanimePlayer() {
     _8C = 0;
     mTargetRotation.zero();
     mKilledByStar = false;
@@ -137,8 +138,7 @@ void GhostPlayer::init(const JMapInfoIter& rIter) {
     char gstPath[256];
     char arcPath[256];
 
-    RaceManagerLayout* layout = new RaceManagerLayout("レース管理用レイアウト");
-    mRaceManagerLayout = layout;
+    mRaceManagerLayout = new RaceManagerLayout("レース管理用レイアウト");
     mRaceManagerLayout->init(rIter);
 
     mCurrentPacket = nullptr;
@@ -162,11 +162,12 @@ void GhostPlayer::init(const JMapInfoIter& rIter) {
     if (mCurrentPacket == nullptr) {
         makeActorDead();
         return;
+    }
+
+    if (MR::isPlayerLuigi()) {
+        initModelManagerWithAnm("GhostLuigi", nullptr, false);
     } else {
-        if (MR::isPlayerLuigi())
-            initModelManagerWithAnm("GhostLuigi", nullptr, false);
-        else
-            initModelManagerWithAnm("GhostMario", nullptr, false);
+        initModelManagerWithAnm("GhostMario", nullptr, false);
     }
 
     initEffectKeeper(5, "GhostMario", false);
@@ -226,42 +227,58 @@ void GhostPlayer::appear() {
 }
 
 void GhostPlayer::control() {
-    if (!mWaitingToStart && !MR::isDead(this)) {
-        MR::startLevelSound(this, "SE_BM_LV_GHOST_MARIO_AMBIENT");
-        if (!isNerve(&NrvGhostPlayer::HostTypeNrvLostDemo::sInstance) && !isNerve(&NrvGhostPlayer::HostTypeNrvWinDemo::sInstance)) {
-            if (!strcmp("powerstarget", MR::getPlayerCurrentBckName()) && isNerve(&NrvGhostPlayer::HostTypeNrvRun::sInstance)) {
-                setNerve(&NrvGhostPlayer::HostTypeNrvLostDemo::sInstance);
-                mKilledByStar = true;
-            } else if (mCurrentPacket) {
-                u32 packetDelayTimer = 0;
-                while (true) {
-                    GhostPacket packet(mCurrentPacket, 0);
-                    mCurrentPacket = reinterpret_cast< GhostPacket* >(reinterpret_cast< char* >(mCurrentPacket) + receiveGhostPacket(&packet));
-                    if (_112) {
-                        if (mXanimePlayer->_10[3] > 0.9f)
-                            continue;
+    if (mWaitingToStart) {
+        return;
+    }
+    if (MR::isDead(this)) {
+        return;
+    }
 
-                        _112 = false;
-                        packetDelayTimer = 10;
-                        continue;
-                    }
+    MR::startLevelSound(this, "SE_BM_LV_GHOST_MARIO_AMBIENT");
 
-                    if (packetDelayTimer == 0)
-                        break;
-                    packetDelayTimer--;
+    if (isNerve(&NrvGhostPlayer::HostTypeNrvLostDemo::sInstance)) {
+        return;
+    }
+    if (isNerve(&NrvGhostPlayer::HostTypeNrvWinDemo::sInstance)) {
+        return;
+    }
+
+    if (strcmp("powerstarget", MR::getPlayerCurrentBckName()) == 0 && isNerve(&NrvGhostPlayer::HostTypeNrvRun::sInstance)) {
+        setNerve(&NrvGhostPlayer::HostTypeNrvLostDemo::sInstance);
+        mKilledByStar = true;
+    } else if (mCurrentPacket) {
+        u32 packetDelayTimer = 0;
+        while (true) {
+            GhostPacket packet(mCurrentPacket, 0);
+            mCurrentPacket = reinterpret_cast< GhostPacket* >(reinterpret_cast< char* >(mCurrentPacket) + receiveGhostPacket(&packet));
+            if (_112) {
+                if (mXanimePlayer->_10[3] > 0.9f) {
+                    continue;
                 }
-                if (mAppearStarPieceCooldown)
-                    mAppearStarPieceCooldown--;
-                if (mPlayerTrampleCooldown)
-                    mPlayerTrampleCooldown--;
+                _112 = false;
+                packetDelayTimer = 10;
+                continue;
             }
+
+            if (packetDelayTimer == 0) {
+                break;
+            }
+            packetDelayTimer--;
+        }
+
+        if (mAppearStarPieceCooldown) {
+            mAppearStarPieceCooldown--;
+        }
+        if (mPlayerTrampleCooldown) {
+            mPlayerTrampleCooldown--;
         }
     }
 }
 
 void GhostPlayer::exeWait() {
-    if (mRaceManagerLayout->isAllAnimStopped())
+    if (mRaceManagerLayout->isAllAnimStopped()) {
         mRaceManagerLayout->kill();
+    }
 }
 
 void GhostPlayer::warpPosition(const char* pName) {
@@ -296,21 +313,21 @@ void GhostPlayer::exePreStartDemo0() {
         MR::requestMovementOn(this);
         MR::requestMovementOnPlayer();
     }
-    if (getNerveStep() == 0x3C) {
+    if (getNerveStep() == 60) {
         mIsHidden = false;
         setAnimation("ゴースト出現");
         MR::validateShadow(this, nullptr);
     }
-    if (getNerveStep() == 0x6B) {
+    if (getNerveStep() == 107) {
         MR::startSound(this, "SE_BV_GHOST_MARIO_LAND");
     }
-    if (getNerveStep() == 0x6F) {
+    if (getNerveStep() == 111) {
         MR::startSound(this, "SE_BM_GHOST_MARIO_LAND");
     }
-    if (getNerveStep() == 0x92) {
+    if (getNerveStep() == 146) {
         MR::startSound(this, "SE_BV_GHOST_MARIO_PROVOKE");
     }
-    if (getNerveStep() == 0xF0) {
+    if (getNerveStep() == 240) {
         MR::endMultiActorCamera(this, mCameraInfo, "レース開始1", false, -1);
         TPos3f* cameraTargetMatrix = &mCameraTargetMtx->mMatrix;
         cameraTargetMatrix->set(getBaseMtx());
@@ -321,7 +338,7 @@ void GhostPlayer::exePreStartDemo0() {
         MR::endMultiActorCamera(this, mCameraInfo, "レース開始1", false, -1);
         MR::startMultiActorCameraTargetSelf(this, mCameraInfo, "レース開始3", -1);
         setNerve(&NrvGhostPlayer::HostTypeNrvPreStartDemo2::sInstance);
-        if (getNerveStep() < 0x3C) {
+        if (getNerveStep() < 60) {
             mIsHidden = false;
             setAnimation("ゴースト出現");
             MR::validateShadow(this, nullptr);
@@ -330,13 +347,14 @@ void GhostPlayer::exePreStartDemo0() {
 }
 
 bool GhostPlayer::isRequestSkipDemo() const {
-    if (MR::hasRetryGalaxySequence() && MR::testCorePadTriggerA(0))
+    if (MR::hasRetryGalaxySequence() && MR::testCorePadTriggerA(WPAD_CHAN0)) {
         return true;
+    }
     return false;
 }
 
 void GhostPlayer::exePreStartDemo1() {
-    if (getNerveStep() == 0xF0) {
+    if (getNerveStep() == 240) {
         MR::endMultiActorCamera(this, mCameraInfo, "レース開始2", false, -1);
         MR::startMultiActorCameraTargetSelf(this, mCameraInfo, "レース開始3", -1);
         setNerve(&NrvGhostPlayer::HostTypeNrvPreStartDemo2::sInstance);
@@ -368,7 +386,7 @@ void GhostPlayer::exePreStartDemo2() {
     if (MR::getPlayerTriggerZ()) {
         MR::startBckPlayerJ("レースクラウチング開始");
         MR::startSoundPlayer("SE_PV_SQUAT", -1);
-    } else if (MR::testSubPadReleaseZ(0)) {
+    } else if (MR::testSubPadReleaseZ(WPAD_CHAN0)) {
         MR::startBckPlayerJ("レース開始");
     }
 
@@ -438,8 +456,9 @@ void GhostPlayer::exeWinDemo() {
         MR::tryStartDemo(this, "レース終了");
         MR::requestMovementOn(this);
         MR::requestMovementOnPlayer();
-        if (mPowerStarTarget)
+        if (mPowerStarTarget) {
             MR::requestMovementOn(mPowerStarTarget);
+        }
     }
 
     if (mPowerStarTarget) {
@@ -448,7 +467,7 @@ void GhostPlayer::exeWinDemo() {
         MR::extractMtxTrans(getBaseMtx(), &mPosition);
     }
 
-    if (MR::isStep(this, 0xB4)) {
+    if (MR::isStep(this, 180)) {
         if (mIsDemoCameraActive) {
             MR::endMultiActorCamera(this, mCameraInfo, "レース終了", true, -1);
             mIsDemoCameraActive = false;
@@ -468,18 +487,18 @@ void GhostPlayer::exeLostDemo() {
 }
 
 void GhostPlayer::calcAndSetBaseMtx() {
-    if (!MR::isDead(this)) {
-        J3DModel* model = MR::getJ3DModel(this);
-        MtxPtr baseMtx = model->getBaseTRMtx();
+    if (MR::isDead(this)) {
+        return;
+    }
 
-        MR::blendMtxRotate(getBaseMtx(), mTargetRotationMtx, 0.2f, baseMtx);
-        MR::setMtxTrans(baseMtx, mPosition.x, mPosition.y, mPosition.z);
-        MR::getJ3DModel(this)->setBaseScale(mScale);
+    MtxPtr baseMtx = MR::getJ3DModel(this)->getBaseTRMtx();
+    MR::blendMtxRotate(getBaseMtx(), mTargetRotationMtx, 0.2f, baseMtx);
+    MR::setMtxTrans(baseMtx, mPosition.x, mPosition.y, mPosition.z);
+    MR::getJ3DModel(this)->setBaseScale(mScale);
 
-        if (mHasJetTurtle) {
-            mHandRPos->calc();
-            mJetTurtleShadow->calcType0(mHandRPos->mMtx);
-        }
+    if (mHasJetTurtle) {
+        mHandRPos->calc();
+        mJetTurtleShadow->calcType0(mHandRPos->mMtx);
     }
 }
 
@@ -542,8 +561,9 @@ void GhostPlayer::attackSensor(HitSensor* pSender, HitSensor* pReceiver) {
 }
 
 bool GhostPlayer::receiveMsgPlayerAttack(u32 msg, HitSensor* pSender, HitSensor* pReceiver) {
-    if (MR::isMsgJetTurtleAttack(msg))
+    if (MR::isMsgJetTurtleAttack(msg)) {
         return true;
+    }
     if (MR::isMsgPlayerTrample(msg) && mPlayerTrampleCooldown == 0) {
         TVec3f frontVec;
         TVec3f upVec;
@@ -570,19 +590,25 @@ bool GhostPlayer::receiveOtherMsg(u32 msg, HitSensor* pSender, HitSensor* pRecei
 }
 
 void GhostPlayer::draw() const {
-    if (!MR::isDead(this) && !mIsHidden) {
-        J3DModelX* model = reinterpret_cast< J3DModelX* >(MR::getJ3DModel(this));
-        model->viewCalc2();
-        GXInvalidateVtxCache();
-        model->mFlags.clear();
-        model->directDraw(nullptr);
-        if (mHasJetTurtle)
-            mJetTurtleShadow->drawType1();
-
-        GXSetAlphaUpdate(GX_FALSE);
-        GXSetColorUpdate(GX_TRUE);
-        GXSetDstAlpha(GX_FALSE, 0);
+    if (MR::isDead(this)) {
+        return;
     }
+    if (mIsHidden) {
+        return;
+    }
+
+    J3DModelX* model = reinterpret_cast< J3DModelX* >(MR::getJ3DModel(this));
+    model->viewCalc2();
+    GXInvalidateVtxCache();
+    model->mFlags.clear();
+    model->directDraw(nullptr);
+    if (mHasJetTurtle) {
+        mJetTurtleShadow->drawType1();
+    }
+
+    GXSetAlphaUpdate(GX_FALSE);
+    GXSetColorUpdate(GX_TRUE);
+    GXSetDstAlpha(GX_FALSE, 0);
 }
 
 u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
@@ -667,14 +693,14 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
         playSound(this, animName);
 
         bool isSpecialAnim = false;
-        if (!strcmp(animName, "基本")) {
+        if (strcmp(animName, "基本") == 0) {
             isSpecialAnim = true;
             setAnimationWeight(&mAnimTrackWeights[0]);
-        } else if (!strcmp(animName, "壁押し")) {
+        } else if (strcmp(animName, "壁押し") == 0) {
             isSpecialAnim = true;
-        } else if (!strcmp(animName, "しゃがみ歩き")) {
+        } else if (strcmp(animName, "しゃがみ歩き") == 0) {
             isSpecialAnim = true;
-        } else if (!strcmp(animName, "がんばり走り")) {
+        } else if (strcmp(animName, "がんばり走り") == 0) {
             isSpecialAnim = true;
         }
 
@@ -692,28 +718,34 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
         const char* currentAnimName = mXanimePlayer->getCurrentAnimationName();
         playSound(this, currentAnimName);
 
-        if (!strcmp(currentAnimName, "基本")) {
+        if (strcmp(currentAnimName, "基本") == 0) {
             isSpecialAnim = true;
             setAnimationWeight(&mAnimTrackWeights[0]);
         }
-        if (!strcmp(currentAnimName, "壁押し"))
+        if (strcmp(currentAnimName, "壁押し") == 0) {
             isSpecialAnim = true;
-        if (!strcmp(currentAnimName, "しゃがみ歩き"))
+        }
+        if (strcmp(currentAnimName, "しゃがみ歩き") == 0) {
             isSpecialAnim = true;
-        if (!strcmp(currentAnimName, "がんばり走り"))
+        }
+        if (strcmp(currentAnimName, "がんばり走り") == 0) {
             isSpecialAnim = true;
-        if (!strcmp(currentAnimName, "スケートアクセルジャンプ"))
+        }
+        if (strcmp(currentAnimName, "スケートアクセルジャンプ") == 0) {
             isSpecialAnim = true;
-        if (!strcmp(currentAnimName, "スケートジャンプ2"))
+        }
+        if (strcmp(currentAnimName, "スケートジャンプ2") == 0) {
             isSpecialAnim = true;
-        if (!strcmp(currentAnimName, "スケートジャンプ3"))
+        }
+        if (strcmp(currentAnimName, "スケートジャンプ3") == 0) {
             isSpecialAnim = true;
+        }
 
-        if (strstr(currentAnimName, "水泳ジェット"))
+        if (strstr(currentAnimName, "水泳ジェット")) {
             mHasJetTurtle = true;
-        else if (strstr(currentAnimName, "カメ持ち"))
+        } else if (strstr(currentAnimName, "カメ持ち")) {
             mHasJetTurtle = true;
-        else if (strstr(currentAnimName, "投げ")) {
+        } else if (strstr(currentAnimName, "投げ")) {
             mHasJetTurtle = false;
             mXanimePlayerUpper->stopAnimation();
             MR::getJ3DModelData(this)->getJointTree().getJointNodePointer(MR::getJointIndex(this, "Spine1"))->setMtxCalc(nullptr);
@@ -738,16 +770,19 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
     }
 
     for (u32 i = 0; i < ARRAY_SIZE(mAnimTrackWeights); i++) {
-        if ((updateFlags & (0x40 << i)) != 0) {
-            s8 rawTrackWeight;
-            f32 trackWeight;
-            pPacket->read(&rawTrackWeight);
-            if ((u8)rawTrackWeight == 0x80)
-                rawTrackWeight = 0x7F;
-            MR::convToFloat(rawTrackWeight, 7, &trackWeight);
-            mXanimePlayer->changeTrackWeight(i, trackWeight);
-            mAnimTrackWeights[i] = trackWeight;
+        if ((updateFlags & (0x40 << i)) == 0) {
+            continue;
         }
+
+        s8 rawTrackWeight;
+        f32 trackWeight;
+        pPacket->read(&rawTrackWeight);
+        if ((u8)rawTrackWeight == 128) {
+            rawTrackWeight = 127;
+        }
+        MR::convToFloat(rawTrackWeight, 7, &trackWeight);
+        mXanimePlayer->changeTrackWeight(i, trackWeight);
+        mAnimTrackWeights[i] = trackWeight;
     }
 
     if ((updateFlags & 0x1000) != 0) {
@@ -762,10 +797,10 @@ u32 GhostPlayer::receiveGhostPacket(GhostPacket* pPacket) {
 }
 
 f32 getShiftRatio(s8 shiftValue) {
-    if (shiftValue > 0)
+    if (shiftValue > 0) {
         return static_cast< f32 >(256 << shiftValue) / 256.0f;
-    else
-        return static_cast< f32 >(256 >> -shiftValue) / 256.0f;
+    }
+    return static_cast< f32 >(256 >> -shiftValue) / 256.0f;
 }
 
 namespace MR {
@@ -792,7 +827,7 @@ namespace MR {
         f32 factor = 1.0f / getShiftRatio(shiftValue);
         *pOutFloat = static_cast< f32 >(inS8) * factor;
     }
-}  // namespace MR
+};  // namespace MR
 
 GhostPlayer::~GhostPlayer() {
 }
@@ -802,8 +837,8 @@ struct BallData {
     f32 value1;
     u32 value2;
 };
-BallData ballData[30] = {{0.0f, 0x00000000},  {0.0f, 0x00000000}, {0.0f, 0x00000000}, {0.0f, 0xFFFFFFFF},  {8.0f, 0x0000FFC0},  {0.0f, 0x0000FFC0},
-                         {10.0f, 0xFF00FFFF}, {8.0f, 0x0000FFC0}, {0.0f, 0x0000FFC0}, {10.0f, 0xFF00FFFF}, {10.0f, 0x000000FF}, {6.0f, 0x000000FF},
-                         {15.0f, 0xFFFF40FF}, {0.0f, 0x00000000}, {0.0f, 0x00000000}, {0.0f, 0x00000000},  {0.0f, 0x00000000},  {0.0f, 0x00000000},
-                         {0.0f, 0x00000000},  {0.0f, 0xFF0000C0}, {6.0f, 0xFF0000C0}, {6.0f, 0xFF0000C0},  {0.0f, 0xFF0000C0},  {10.0f, 0xFF0000FF},
-                         {0.0f, 0xFF0000C0},  {6.0f, 0xFF0000C0}, {6.0f, 0xFF0000C0}, {0.0f, 0xFF0000C0},  {10.0f, 0xFF0000FF}, {0.0f, 0x00000000}};
+BallData ballData[] = {{0.0f, 0x00000000},  {0.0f, 0x00000000}, {0.0f, 0x00000000}, {0.0f, 0xFFFFFFFF},  {8.0f, 0x0000FFC0},  {0.0f, 0x0000FFC0},
+                       {10.0f, 0xFF00FFFF}, {8.0f, 0x0000FFC0}, {0.0f, 0x0000FFC0}, {10.0f, 0xFF00FFFF}, {10.0f, 0x000000FF}, {6.0f, 0x000000FF},
+                       {15.0f, 0xFFFF40FF}, {0.0f, 0x00000000}, {0.0f, 0x00000000}, {0.0f, 0x00000000},  {0.0f, 0x00000000},  {0.0f, 0x00000000},
+                       {0.0f, 0x00000000},  {0.0f, 0xFF0000C0}, {6.0f, 0xFF0000C0}, {6.0f, 0xFF0000C0},  {0.0f, 0xFF0000C0},  {10.0f, 0xFF0000FF},
+                       {0.0f, 0xFF0000C0},  {6.0f, 0xFF0000C0}, {6.0f, 0xFF0000C0}, {0.0f, 0xFF0000C0},  {10.0f, 0xFF0000FF}, {0.0f, 0x00000000}};


### PR DESCRIPTION
- Add to `GhostPlayer` implementation
- Add empty `TVec3` constructor
- Include `J3DJoint.hpp` instead of `J3DMtxCalc.hpp` in `XanimeCore`
- Added/adjusted splits for `GhostPlayer`, affecting `GroupChecker`, `MarineSnow`, and `MarioActor`

Note that I updated an include in `XanimeCore.hpp` from `J3DMtxCalc.hpp` to `J3DJoint.hpp`. There seems to be two declarations of `J3DMtxCalc` in the codebase, and the one inside `J3DMtxCalc.hpp` is missing required members. My intuition says this is a bad idea, so I'd appreciate guidance on the proper fix. Additionally, it seems that `J3DMtxCalc.hpp` is no longer being referenced elsewhere, so it might be better to migrate the headers over, but I don't know if that sentiment is shared.