### PR TITLE
Update macOS wine instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,19 @@ macOS
   brew install ninja
   ```
 
-- Install [wine-crossover](https://github.com/Gcenx/homebrew-wine):
+- Install [wine-stable](https://github.com/Gcenx/macOS_Wine_builds):
 
   ```sh
-  brew install --cask --no-quarantine gcenx/wine/wine-crossover
+  brew install --cask wine-stable
   ```
 
-After OS upgrades, if macOS complains about `Wine Crossover.app` being unverified, you can unquarantine it using:
+> [!NOTE]
+> The previously recommended `wine-crossover` cask has been discontinued; its cask was removed from the `gcenx/wine` tap and its downloads are no longer hosted. Current WineHQ builds support running 32-bit Windows binaries out of the box. If the `wine-stable` cask is unavailable, official builds can be downloaded from [Gcenx/macOS_Wine_builds](https://github.com/Gcenx/macOS_Wine_builds/releases).
+
+Since the WineHQ builds are not notarized, macOS may block `Wine Stable.app` from running. If `wine` is killed on launch, unquarantine it using:
 
 ```sh
-sudo xattr -rd com.apple.quarantine '/Applications/Wine Crossover.app'
+sudo xattr -rd com.apple.quarantine '/Applications/Wine Stable.app'
 ```
 
 Linux


### PR DESCRIPTION
The macOS dependency instructions no longer work: the `wine-crossover` cask was deleted from the `gcenx/wine` tap ([commit](https://github.com/Gcenx/homebrew-wine/commit/f201026)), and the release downloads it pointed to (`Gcenx/winecx` crossover-wine-23.7.1-1) now return 404. So `brew install --cask --no-quarantine gcenx/wine/wine-crossover` fails with "No casks found for wine-crossover".

This updates the README to recommend the WineHQ `wine-stable` cask instead. Current WineHQ macOS builds run 32-bit Windows binaries via wow64, and I've verified the full flow on an Apple Silicon Mac (macOS 26, wine 11.0): install, unquarantine, `configure.py`, and `ninja` (which proceeds correctly up to requiring `orig/RMGK01`).

Two notes folded into the README text:
- The WineHQ builds are not notarized, so Gatekeeper kills `wine` on first launch (exit 137) until the app is unquarantined - kept the existing `xattr` tip, updated for `Wine Stable.app`.
- Also linked [Gcenx/macOS_Wine_builds](https://github.com/Gcenx/macOS_Wine_builds/releases) as a fallback, since Homebrew has deprecated the `wine-stable` cask (scheduled to be disabled 2026-09-01 for failing notarization checks). Happy to reword toward the manual download as the primary path if you'd prefer something more future-proof.