### PR TITLE
ParticleEmitterHolder matching

### DIFF
--- a/config/RMGK01/splits.txt
+++ b/config/RMGK01/splits.txt
@@ -2453,11 +2453,11 @@ Game/Effect/ParticleEmitter.cpp:
 	.text       start:0x800C9FB4 end:0x800CA05C
 
 Game/Effect/ParticleEmitterHolder.cpp:
-	.text       start:0x800CA05C end:0x800CA47C
+	.text       start:0x800CA05C end:0x800CA448
 	.data       start:0x805787C8 end:0x805787D8
 
 Game/Effect/ParticleResourceHolder.cpp:
-	.text       start:0x800CA47C end:0x800CA934
+	.text       start:0x800CA448 end:0x800CA934
 	.data       start:0x805787D8 end:0x80578820
 	.sdata      start:0x806B18A0 end:0x806B18A8
 

--- a/include/Game/Effect/ParticleEmitterHolder.hpp
+++ b/include/Game/Effect/ParticleEmitterHolder.hpp
@@ -7,9 +7,15 @@ class EffectSystem;
 
 class ParticleEmitterHolder {
 public:
-    ParticleEmitterHolder(EffectSystem const*, int);
+    ParticleEmitterHolder(const EffectSystem*, int);
 
-    EffectSystem const* mEffectSystem;                 // 0x0
-    MR::AssignableArray< ParticleEmitter > mEmitters;  // 0x4
-    int mNumEmitters;                                  // 0x8
+    void update(bool);
+    void forceDeleteAllOneTimeEmitters();
+    void forceDeleteAllEmitters();
+    void requestMovementOnAllEmitters();
+    ParticleEmitter* findAvailableParticleEmitter();
+    void requestMovementOffAllLoopEmitters();
+
+    /* 0x0 */ const EffectSystem* mEffectSystem;
+    /* 0x4 */ MR::AssignableArray< ParticleEmitter > mEmitters;
 };

--- a/libs/MSL_C++/include/algorithm
+++ b/libs/MSL_C++/include/algorithm
@@ -51,6 +51,13 @@ namespace std {
     }
 
     template < class InputIt, class UnaryPredicate >
+    InputIt* find_if_array(InputIt* first, InputIt* last, UnaryPredicate p) {
+        for (; first != last && !p(first); ++first) {
+        }
+        return first;
+    }
+
+    template < class InputIt, class UnaryPredicate >
     InputIt rfind_if(InputIt first, InputIt last, UnaryPredicate p) {
         for (; first != last && !p(*first); --first) {
         }

--- a/src/Game/Effect/ParticleEmitterHolder.cpp
+++ b/src/Game/Effect/ParticleEmitterHolder.cpp
@@ -1,9 +1,92 @@
 #include "Game/Effect/ParticleEmitterHolder.hpp"
 #include "Game/Effect/EffectSystem.hpp"
+#include "Game/Effect/EffectSystemUtil.hpp"
+#include "Game/Effect/ParticleEmitter.hpp"
 
-// Not sure how to make this match.
-// ParticleEmitterHolder::ParticleEmitterHolder(EffectSystem const *pEffectSystem, int numEmitters) {
-//     mEffectSystem = pEffectSystem;
-//     mEmitters.init(numEmitters);
-//     mNumEmitters = numEmitters;
-// }
+#include <JSystem/JParticle/JPAEmitter.hpp>
+#include <algorithm>
+
+ParticleEmitterHolder::ParticleEmitterHolder(const EffectSystem* pEffectSystem, int numEmitters) : mEffectSystem(pEffectSystem) {
+    mEmitters.init(numEmitters);
+}
+
+void ParticleEmitterHolder::update(bool param1) {
+    for (ParticleEmitter* pEmitter = mEmitters.begin(); pEmitter != mEmitters.end(); pEmitter++) {
+        JPABaseEmitter* pBaseEmitter = pEmitter->mEmitter;
+        if (pBaseEmitter == nullptr) {
+            continue;
+        }
+
+        if (param1 != (pBaseEmitter->getGroupID() == 1)) {
+            continue;
+        }
+
+        const bool shouldDelete = pBaseEmitter->checkStatus(0x8) && pBaseEmitter->getParticleNumber() == 0;
+
+        if (shouldDelete) {
+            mEffectSystem->forceDeleteEmitter(pEmitter);
+        } else if (!pEmitter->mStopped) {
+            if (MR::Effect::getLinkSingleEmitter(pBaseEmitter)) {
+                pBaseEmitter->getEmitterCallBackPtr()->init(pBaseEmitter);
+            }
+            pEmitter->mStopped = true;
+        }
+    }
+}
+
+void ParticleEmitterHolder::forceDeleteAllOneTimeEmitters() {
+    for (ParticleEmitter* pEmitter = mEmitters.begin(); pEmitter != mEmitters.end(); pEmitter++) {
+        if (pEmitter->mEmitter == nullptr) {
+            continue;
+        }
+
+        if (pEmitter->isContinuousParticle()) {
+            continue;
+        }
+
+        mEffectSystem->forceDeleteEmitter(pEmitter);
+    }
+}
+
+void ParticleEmitterHolder::forceDeleteAllEmitters() {
+    for (ParticleEmitter* pEmitter = mEmitters.begin(); pEmitter != mEmitters.end(); pEmitter++) {
+        mEffectSystem->forceDeleteEmitter(pEmitter);
+    }
+}
+
+void ParticleEmitterHolder::requestMovementOnAllEmitters() {
+    for (ParticleEmitter* pEmitter = mEmitters.begin(); pEmitter != mEmitters.end(); pEmitter++) {
+        JPABaseEmitter* pBaseEmitter = pEmitter->mEmitter;
+        if (pBaseEmitter == nullptr) {
+            continue;
+        }
+
+        if (pBaseEmitter->getGroupID() == 1 || pBaseEmitter->getGroupID() == 7) {
+            continue;
+        }
+
+        pEmitter->pauseOff();
+    }
+}
+
+ParticleEmitter* ParticleEmitterHolder::findAvailableParticleEmitter() {
+    ParticleEmitter* res = std::find_if_array(mEmitters.begin(), mEmitters.end(), std::not1(std::mem_func(&ParticleEmitter::isValid)));
+    if (res == mEmitters.end()) {
+        return nullptr;
+    }
+    return res;
+}
+
+void ParticleEmitterHolder::requestMovementOffAllLoopEmitters() {
+    for (ParticleEmitter* pEmitter = mEmitters.begin(); pEmitter != mEmitters.end(); pEmitter++) {
+        if (pEmitter->mEmitter == nullptr) {
+            continue;
+        }
+
+        if (!pEmitter->isContinuousParticle()) {
+            continue;
+        }
+
+        pEmitter->pauseOn();
+    }
+}


### PR DESCRIPTION
I've also changed the split to move `ParticleEmitter::isValid() const` and `ParticleEmitter::isContinuousParticle() const` into the `ParticleResourceHolder` TU to prevent them from being inlined in `ParticleEmitterHolder`. These symbols are also unused in `ParticleResourceHolder` so they are probably inlined there.